### PR TITLE
Carthageでライブラリを導入する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ playground.xcworkspace
 # Carthage
 #
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
-# Carthage/Checkouts
+Carthage/Checkouts
 
 Carthage/Build
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,3 @@
+github "Alamofire/Alamofire"
+github "Alamofire/AlamofireImage"
+github "SwiftyJSON/SwiftyJSON"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,3 @@
+github "Alamofire/Alamofire" "4.0.1"
+github "SwiftyJSON/SwiftyJSON" "3.1.0"
+github "Alamofire/AlamofireImage" "3.0.0"

--- a/Turmeric.xcodeproj/project.pbxproj
+++ b/Turmeric.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		5242ABF81D98F1BE0095D4F4 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5242ABF71D98F1BE0095D4F4 /* ViewController.swift */; };
 		5242ABFB1D98F1CB0095D4F4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5242ABF91D98F1CB0095D4F4 /* LaunchScreen.storyboard */; };
 		5242ABFC1D98F1CB0095D4F4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5242ABFA1D98F1CB0095D4F4 /* Main.storyboard */; };
+		525B707B1D98F985004D72BD /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 525B70781D98F985004D72BD /* Alamofire.framework */; };
+		525B707C1D98F985004D72BD /* AlamofireImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 525B70791D98F985004D72BD /* AlamofireImage.framework */; };
+		525B707D1D98F985004D72BD /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 525B707A1D98F985004D72BD /* SwiftyJSON.framework */; };
 		52B1C6DD1D98EFD2002AB83B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B1C6DC1D98EFD2002AB83B /* AppDelegate.swift */; };
 		52B1C6E41D98EFD2002AB83B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 52B1C6E31D98EFD2002AB83B /* Assets.xcassets */; };
 		52B1C6F21D98EFD2002AB83B /* TurmericTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B1C6F11D98EFD2002AB83B /* TurmericTests.swift */; };
@@ -37,6 +40,9 @@
 		5242ABF71D98F1BE0095D4F4 /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		5242ABF91D98F1CB0095D4F4 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		5242ABFA1D98F1CB0095D4F4 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+		525B70781D98F985004D72BD /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
+		525B70791D98F985004D72BD /* AlamofireImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AlamofireImage.framework; path = Carthage/Build/iOS/AlamofireImage.framework; sourceTree = "<group>"; };
+		525B707A1D98F985004D72BD /* SwiftyJSON.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyJSON.framework; path = Carthage/Build/iOS/SwiftyJSON.framework; sourceTree = "<group>"; };
 		52B1C6D91D98EFD2002AB83B /* Turmeric.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Turmeric.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		52B1C6DC1D98EFD2002AB83B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		52B1C6E31D98EFD2002AB83B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -54,6 +60,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				525B707B1D98F985004D72BD /* Alamofire.framework in Frameworks */,
+				525B707C1D98F985004D72BD /* AlamofireImage.framework in Frameworks */,
+				525B707D1D98F985004D72BD /* SwiftyJSON.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -131,6 +140,16 @@
 			path = Storyboards;
 			sourceTree = "<group>";
 		};
+		525B70771D98F985004D72BD /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				525B70781D98F985004D72BD /* Alamofire.framework */,
+				525B70791D98F985004D72BD /* AlamofireImage.framework */,
+				525B707A1D98F985004D72BD /* SwiftyJSON.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		52B1C6D01D98EFD1002AB83B = {
 			isa = PBXGroup;
 			children = (
@@ -138,6 +157,7 @@
 				52B1C6F01D98EFD2002AB83B /* TurmericTests */,
 				52B1C6FB1D98EFD2002AB83B /* TurmericUITests */,
 				52B1C6DA1D98EFD2002AB83B /* Products */,
+				525B70771D98F985004D72BD /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -191,6 +211,7 @@
 				52B1C6D51D98EFD1002AB83B /* Sources */,
 				52B1C6D61D98EFD1002AB83B /* Frameworks */,
 				52B1C6D71D98EFD1002AB83B /* Resources */,
+				525B707E1D98F9B6004D72BD /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -309,6 +330,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		525B707E1D98F9B6004D72BD /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/Alamofire.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/AlamofireImage.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/SwiftyJSON.framework",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		52B1C6D51D98EFD1002AB83B /* Sources */ = {
@@ -447,6 +487,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = Turmeric/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pepabo.training.Turmeric;
@@ -459,6 +503,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = Turmeric/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pepabo.training.Turmeric;


### PR DESCRIPTION
すぐ必要になるであろうAlamofire, AlamofireImage, SwiftyJSONを導入します

ライブラリのソースコードをリポジトリに含めると巨大になるので含めないようにしました。
CIの中でCarthageを使うようにして、適切にキャッシュを設定すれば問題ないようです。
ref: sunsetチーム https://github.com/pepabo-mobile-app-training/sunset/pull/9
