### PR TITLE
Bitriseのwarning対策のため、schemeをsharedにする

### DIFF
--- a/Turmeric.xcodeproj/xcshareddata/xcschemes/Turmeric.xcscheme
+++ b/Turmeric.xcodeproj/xcshareddata/xcschemes/Turmeric.xcscheme
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0800"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "52B1C6D81D98EFD1002AB83B"
+               BuildableName = "Turmeric.app"
+               BlueprintName = "Turmeric"
+               ReferencedContainer = "container:Turmeric.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "52B1C6EC1D98EFD2002AB83B"
+               BuildableName = "TurmericTests.xctest"
+               BlueprintName = "TurmericTests"
+               ReferencedContainer = "container:Turmeric.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "52B1C6F71D98EFD2002AB83B"
+               BuildableName = "TurmericUITests.xctest"
+               BlueprintName = "TurmericUITests"
+               ReferencedContainer = "container:Turmeric.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "52B1C6D81D98EFD1002AB83B"
+            BuildableName = "Turmeric.app"
+            BlueprintName = "Turmeric"
+            ReferencedContainer = "container:Turmeric.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "52B1C6D81D98EFD1002AB83B"
+            BuildableName = "Turmeric.app"
+            BlueprintName = "Turmeric"
+            ReferencedContainer = "container:Turmeric.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "52B1C6D81D98EFD1002AB83B"
+            BuildableName = "Turmeric.app"
+            BlueprintName = "Turmeric"
+            ReferencedContainer = "container:Turmeric.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Bitrise CIの設定を進めていたら、`No Shared Scheme Found For Project: Turmeric.Xcodeproj`というwarningが出ました

http://devcenter.bitrise.io/docs/scheme-cannot-be-found

schemeがよくわからないので調べたところ、

http://www.oreilly.co.jp/community/blog/2014/05/scheme-and-build-settings-in-ios-development.html

> スキーマとビルド設定とは？
> 
> ビルド設定とは？
> 「ビルド設定」とは、文字通りビルドを行うときの各種設定のセットです。ビルド設定ごとに使用するinfo.plistの選択やプリプロセッサマクロの設定やプロビジョニングプロファイルの設定、その他の細かい設定を保存しておくことができます。
> ビルド設定はXcodeのプロジェクトの編集画面で確認できます（図1）。
> 
> スキーマとは？
> スキーマとはXcodeの実行・テスト・プロファイル・アーカイブを行うときに、どのビルド設定を選択するかをあらかじめ設定しておくためのものです（図2）。
> 実行・テスト・プロファイル・アーカイブにそれぞれ別々のビルド設定を持たせることもできますし、全て同じビルド設定を持たせることもできます。

http://qiita.com/hterada/items/3006a2b6fb57d8cd6c11

> Xcodeのプロジェクトのビルド Scheme は、デフォルトではプロジェクトファイルに紐付いておらず
> バージョン管理ツールにコミットしても他のユーザに共有できない。

とのことでした。
この設定を行うことで、どのビルド設定を選択するか(スキーマ)を自分以外にも共有できるようです。
CIでどのビルド設定を使うかを取得しないといけないので、スキーマの共有が必要ということでしょうか。
