### PR TITLE
バージョンを上げないようにするため`carthage bootstrap`コマンドに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ brew install carthage mergepbx
 ```
 git clone https://github.com/pepabo-mobile-app-training/turmeric.git
 cd turmeric
-carthage update --platform iOS
+carthage bootstrap --platform iOS
 ```
 
 `Turmeric.xcodeproj`をXcodeで開き、シミュレーターでアプリが動けば準備完了


### PR DESCRIPTION
carthageにはcarthage updateのほかに`carthage bootstrap`コマンドがあり、bundlerにおける`bundle install`と`bundle update`の関係に相当するようです。
bootstrapでは更新を行わず、Cartfile.resolvedに基いてソースのダウンロード、ビルドが行われるとのことです。

http://qiita.com/koher/items/a3b254d0195669088e40#cartfileresolved

一応公式の根拠を探してみました。
やや回りくどい書き方になっていますが、Cartfile.resolvedファイルを必ずコミットして`carthage bootstrap`しろと書かれています

https://github.com/Carthage/Carthage#for-both-platforms

> For both platforms
> 
> Along the way, Carthage will have created some build artifacts. The most important of these is the Cartfile.resolved file, which lists the versions that were actually built for each framework. Make sure to commit your Cartfile.resolved, because anyone else using the project will need that file to build the same framework versions.
> 
> After you’ve finished the above steps and pushed your changes, other users of the project only need to fetch the repository and run carthage bootstrap to get started with the frameworks you’ve added.

`carthage help`もあたってみましたが…このヘルプはどうなんでしょうか……

```
   bootstrap         Check out and build the project's dependencies
   update            Update and rebuild the project's dependencies
```
