### PR TITLE
プロフィールページのレイアウト

### DIFF
--- a/Turmeric.xcodeproj/project.pbxproj
+++ b/Turmeric.xcodeproj/project.pbxproj
@@ -27,6 +27,10 @@
 		724DB9151D99271B00008C25 /* Post.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9141D99271B00008C25 /* Post.storyboard */; };
 		724DB9171D99274A00008C25 /* Profile.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9161D99274A00008C25 /* Profile.storyboard */; };
 		724DB9191D99275300008C25 /* Lists.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9181D99275300008C25 /* Lists.storyboard */; };
+		72C0D6E01D9BB50600D47723 /* Feed.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 72C0D6DF1D9BB50600D47723 /* Feed.storyboard */; };
+		72C0D6E21D9BB54A00D47723 /* Following.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 72C0D6E11D9BB54A00D47723 /* Following.storyboard */; };
+		72C0D6E41D9BB56100D47723 /* Followers.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 72C0D6E31D9BB56100D47723 /* Followers.storyboard */; };
+		72C0D6E61D9BB70900D47723 /* ProfileEdit.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 72C0D6E51D9BB70900D47723 /* ProfileEdit.storyboard */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -72,6 +76,10 @@
 		724DB9141D99271B00008C25 /* Post.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Post.storyboard; sourceTree = "<group>"; };
 		724DB9161D99274A00008C25 /* Profile.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Profile.storyboard; sourceTree = "<group>"; };
 		724DB9181D99275300008C25 /* Lists.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Lists.storyboard; sourceTree = "<group>"; };
+		72C0D6DF1D9BB50600D47723 /* Feed.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Feed.storyboard; sourceTree = "<group>"; };
+		72C0D6E11D9BB54A00D47723 /* Following.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Following.storyboard; sourceTree = "<group>"; };
+		72C0D6E31D9BB56100D47723 /* Followers.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Followers.storyboard; sourceTree = "<group>"; };
+		72C0D6E51D9BB70900D47723 /* ProfileEdit.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = ProfileEdit.storyboard; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -165,6 +173,10 @@
 				724DB9161D99274A00008C25 /* Profile.storyboard */,
 				724DB9181D99275300008C25 /* Lists.storyboard */,
 				7231C3D81D9A0BA90086D60F /* Mention.storyboard */,
+				72C0D6DF1D9BB50600D47723 /* Feed.storyboard */,
+				72C0D6E11D9BB54A00D47723 /* Following.storyboard */,
+				72C0D6E31D9BB56100D47723 /* Followers.storyboard */,
+				72C0D6E51D9BB70900D47723 /* ProfileEdit.storyboard */,
 			);
 			path = Storyboards;
 			sourceTree = "<group>";
@@ -341,12 +353,16 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				72C0D6E21D9BB54A00D47723 /* Following.storyboard in Resources */,
 				724DB9171D99274A00008C25 /* Profile.storyboard in Resources */,
 				5242ABFC1D98F1CB0095D4F4 /* Main.storyboard in Resources */,
+				72C0D6E01D9BB50600D47723 /* Feed.storyboard in Resources */,
 				52B1C6E41D98EFD2002AB83B /* Assets.xcassets in Resources */,
 				7231C3D91D9A0BA90086D60F /* Mention.storyboard in Resources */,
 				5242ABFB1D98F1CB0095D4F4 /* LaunchScreen.storyboard in Resources */,
 				724DB9151D99271B00008C25 /* Post.storyboard in Resources */,
+				72C0D6E61D9BB70900D47723 /* ProfileEdit.storyboard in Resources */,
+				72C0D6E41D9BB56100D47723 /* Followers.storyboard in Resources */,
 				724DB9131D9926FB00008C25 /* Home.storyboard in Resources */,
 				724DB9191D99275300008C25 /* Lists.storyboard in Resources */,
 			);

--- a/Turmeric.xcodeproj/project.pbxproj
+++ b/Turmeric.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		72C0D6E41D9BB56100D47723 /* Followers.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 72C0D6E31D9BB56100D47723 /* Followers.storyboard */; };
 		72C0D6E61D9BB70900D47723 /* ProfileEdit.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 72C0D6E51D9BB70900D47723 /* ProfileEdit.storyboard */; };
 		72C0D6E81D9BBC9000D47723 /* LinedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C0D6E71D9BBC9000D47723 /* LinedButton.swift */; };
+		72C0D6EC1D9CBBE200D47723 /* ProfileUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C0D6EB1D9CBBE200D47723 /* ProfileUITests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,6 +83,7 @@
 		72C0D6E31D9BB56100D47723 /* Followers.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Followers.storyboard; sourceTree = "<group>"; };
 		72C0D6E51D9BB70900D47723 /* ProfileEdit.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = ProfileEdit.storyboard; sourceTree = "<group>"; };
 		72C0D6E71D9BBC9000D47723 /* LinedButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinedButton.swift; sourceTree = "<group>"; };
+		72C0D6EB1D9CBBE200D47723 /* ProfileUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileUITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -243,6 +245,7 @@
 			children = (
 				52B1C6FC1D98EFD2002AB83B /* TurmericUITests.swift */,
 				52B1C6FE1D98EFD2002AB83B /* Info.plist */,
+				72C0D6EB1D9CBBE200D47723 /* ProfileUITests.swift */,
 			);
 			path = TurmericUITests;
 			sourceTree = "<group>";
@@ -451,6 +454,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				52B1C6FD1D98EFD2002AB83B /* TurmericUITests.swift in Sources */,
+				72C0D6EC1D9CBBE200D47723 /* ProfileUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Turmeric.xcodeproj/project.pbxproj
+++ b/Turmeric.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		72C0D6E21D9BB54A00D47723 /* Following.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 72C0D6E11D9BB54A00D47723 /* Following.storyboard */; };
 		72C0D6E41D9BB56100D47723 /* Followers.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 72C0D6E31D9BB56100D47723 /* Followers.storyboard */; };
 		72C0D6E61D9BB70900D47723 /* ProfileEdit.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 72C0D6E51D9BB70900D47723 /* ProfileEdit.storyboard */; };
+		72C0D6E81D9BBC9000D47723 /* LinedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C0D6E71D9BBC9000D47723 /* LinedButton.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -80,6 +81,7 @@
 		72C0D6E11D9BB54A00D47723 /* Following.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Following.storyboard; sourceTree = "<group>"; };
 		72C0D6E31D9BB56100D47723 /* Followers.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Followers.storyboard; sourceTree = "<group>"; };
 		72C0D6E51D9BB70900D47723 /* ProfileEdit.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = ProfileEdit.storyboard; sourceTree = "<group>"; };
+		72C0D6E71D9BBC9000D47723 /* LinedButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinedButton.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -159,6 +161,7 @@
 		5242ABF51D98F16A0095D4F4 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				72C0D6E71D9BBC9000D47723 /* LinedButton.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -427,6 +430,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				72C0D6E81D9BBC9000D47723 /* LinedButton.swift in Sources */,
 				5232599F1D9A0D8100476111 /* User.swift in Sources */,
 				5242ABF81D98F1BE0095D4F4 /* ViewController.swift in Sources */,
 				52B1C6DD1D98EFD2002AB83B /* AppDelegate.swift in Sources */,

--- a/Turmeric/Classes/Views/LinedButton.swift
+++ b/Turmeric/Classes/Views/LinedButton.swift
@@ -1,0 +1,23 @@
+//
+//  LinedButton.swift
+//  Turmeric
+//
+//  Created by usr0600437 on 2016/09/28.
+//  Copyright © 2016年 GMO Pepabo. All rights reserved.
+//
+
+import UIKit.UIButton
+
+class LinedButton: UIButton {
+    override func draw(_ rect: CGRect) {
+        // 角丸
+        self.layer.cornerRadius = 5
+        self.clipsToBounds = true
+        
+        // 枠線
+        self.layer.borderColor = self.currentTitleColor.cgColor //文字色と一致させる
+        self.layer.borderWidth = 1
+        
+        super.draw(rect)
+    }
+}

--- a/Turmeric/Storyboards/Feed.storyboard
+++ b/Turmeric/Storyboards/Feed.storyboard
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="31N-up-6C7">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Table View Controller-->
+        <scene sceneID="0J2-83-vIM">
+            <objects>
+                <tableViewController id="31N-up-6C7" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="oha-qm-Txz">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="sSD-Or-qwV">
+                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="sSD-Or-qwV" id="43w-bh-JjL">
+                                    <frame key="frameInset" width="375" height="43"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="31N-up-6C7" id="TcA-NK-aOZ"/>
+                            <outlet property="delegate" destination="31N-up-6C7" id="vam-UF-CmU"/>
+                        </connections>
+                    </tableView>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="r79-hk-YeE" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="226" y="144"/>
+        </scene>
+    </scenes>
+</document>

--- a/Turmeric/Storyboards/Followers.storyboard
+++ b/Turmeric/Storyboards/Followers.storyboard
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="hu7-co-xC7">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="ssR-lW-h7h">
+            <objects>
+                <viewController id="hu7-co-xC7" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="MUF-YQ-MhC"/>
+                        <viewControllerLayoutGuide type="bottom" id="F4e-o2-GNO"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="DL2-NK-lTn">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="LkM-5z-e4O" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="540" y="-112"/>
+        </scene>
+    </scenes>
+</document>

--- a/Turmeric/Storyboards/Following.storyboard
+++ b/Turmeric/Storyboards/Following.storyboard
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="snb-uT-cpS">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="k1y-7M-vbE">
+            <objects>
+                <viewController id="snb-uT-cpS" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="3S3-BY-Tfh"/>
+                        <viewControllerLayoutGuide type="bottom" id="hvy-hX-rm1"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="6mG-wC-7f3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="4QR-ph-LCh" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="354" y="-195"/>
+        </scene>
+    </scenes>
+</document>

--- a/Turmeric/Storyboards/LaunchScreen.storyboard
+++ b/Turmeric/Storyboards/LaunchScreen.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>

--- a/Turmeric/Storyboards/Profile.storyboard
+++ b/Turmeric/Storyboards/Profile.storyboard
@@ -18,13 +18,14 @@
                         <viewControllerLayoutGuide type="bottom" id="Z3F-Cp-n07"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="0O8-3u-tgk">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cnX-NO-a0K" userLabel="IconAndEdit">
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qnu-cd-McX" customClass="LinedButton" customModule="Turmeric" customModuleProvider="target">
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="profileEditButton"/>
                                         <state key="normal" title="編集"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
@@ -42,6 +43,7 @@
                                         </connections>
                                     </button>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="xnf-Iu-OEq">
+                                        <accessibility key="accessibilityConfiguration" identifier="profileImage"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="xnf-Iu-OEq" secondAttribute="height" multiplier="1:1" id="MYE-u1-DWU"/>
                                         </constraints>
@@ -62,6 +64,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="i8V-ir-COL" userLabel="Stat">
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ngK-ft-fVb">
+                                        <accessibility key="accessibilityConfiguration" identifier="profileUsetnameLabel"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -72,6 +75,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1qL-Po-6Tv" userLabel="FollowingButton">
+                                        <accessibility key="accessibilityConfiguration" identifier="profileFollowingCountButton"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <state key="normal" title="100"/>
                                         <connections>
@@ -84,6 +88,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mQj-hl-Bd0" userLabel="FollowersButton">
+                                        <accessibility key="accessibilityConfiguration" identifier="profileFollowersCountButton"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <state key="normal" title="100"/>
                                         <connections>
@@ -91,6 +96,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5,100" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="siK-Xr-AGZ">
+                                        <accessibility key="accessibilityConfiguration" identifier="profileMicropostsCountLabel"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>

--- a/Turmeric/Storyboards/Profile.storyboard
+++ b/Turmeric/Storyboards/Profile.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="s0U-2F-OaN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="AhQ-rM-qjU">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
@@ -17,25 +17,32 @@
                     <view key="view" contentMode="scaleToFill" id="r9h-F7-WWb">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Profile" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MXg-fM-ih5">
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstItem="MXg-fM-ih5" firstAttribute="centerX" secondItem="r9h-F7-WWb" secondAttribute="centerX" id="2mz-z8-7Su"/>
-                            <constraint firstItem="MXg-fM-ih5" firstAttribute="centerY" secondItem="r9h-F7-WWb" secondAttribute="centerY" id="TaI-3u-Y1t"/>
-                        </constraints>
                     </view>
-                    <tabBarItem key="tabBarItem" title="プロフィール" id="YtW-gu-rE6"/>
+                    <navigationItem key="navigationItem" title="プロフィール" id="LW0-wT-rEs"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5Vj-pQ-VNI" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-33" y="-112"/>
+            <point key="canvasLocation" x="272.80000000000001" y="-122.78860569715144"/>
+        </scene>
+        <!--プロフィール-->
+        <scene sceneID="0Oo-Sm-jhh">
+            <objects>
+                <navigationController id="AhQ-rM-qjU" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="プロフィール" id="YtW-gu-rE6"/>
+                    <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="fy8-IM-aRG">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="s0U-2F-OaN" kind="relationship" relationship="rootViewController" id="6T8-se-30e"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="QBt-vO-vi1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-727" y="-123"/>
         </scene>
     </scenes>
 </document>

--- a/Turmeric/Storyboards/Profile.storyboard
+++ b/Turmeric/Storyboards/Profile.storyboard
@@ -23,7 +23,7 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cnX-NO-a0K" userLabel="IconAndEdit">
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qnu-cd-McX" customClass="CustomButton" customModule="Turmeric" customModuleProvider="target">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qnu-cd-McX" customClass="LinedButton" customModule="Turmeric" customModuleProvider="target">
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <state key="normal" title="編集"/>
                                         <userDefinedRuntimeAttributes>

--- a/Turmeric/Storyboards/Profile.storyboard
+++ b/Turmeric/Storyboards/Profile.storyboard
@@ -3,6 +3,9 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -11,20 +14,171 @@
             <objects>
                 <viewController id="s0U-2F-OaN" sceneMemberID="viewController">
                     <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="3ep-DY-DsU"/>
-                        <viewControllerLayoutGuide type="bottom" id="Zys-h2-RRD"/>
+                        <viewControllerLayoutGuide type="top" id="5Cw-4b-JHm"/>
+                        <viewControllerLayoutGuide type="bottom" id="Z3F-Cp-n07"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="r9h-F7-WWb">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    <view key="view" contentMode="scaleToFill" id="0O8-3u-tgk">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cnX-NO-a0K" userLabel="IconAndEdit">
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qnu-cd-McX" customClass="CustomButton" customModule="Turmeric" customModuleProvider="target">
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        <state key="normal" title="編集"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="0.0"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                <color key="value" red="0.0" green="0.25098040700000002" blue="0.50196081400000003" alpha="1" colorSpace="calibratedRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                <real key="value" value="5"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="Sgg-uN-ULc" kind="modal" id="PIL-83-mV2"/>
+                                        </connections>
+                                    </button>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="xnf-Iu-OEq">
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="xnf-Iu-OEq" secondAttribute="height" multiplier="1:1" id="MYE-u1-DWU"/>
+                                        </constraints>
+                                    </imageView>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstItem="Qnu-cd-McX" firstAttribute="centerX" secondItem="xnf-Iu-OEq" secondAttribute="centerX" id="AeJ-oE-XCw"/>
+                                    <constraint firstItem="xnf-Iu-OEq" firstAttribute="leading" secondItem="cnX-NO-a0K" secondAttribute="leading" id="D5P-Ox-bEb"/>
+                                    <constraint firstItem="Qnu-cd-McX" firstAttribute="top" secondItem="xnf-Iu-OEq" secondAttribute="bottom" id="GL0-Eo-2RU"/>
+                                    <constraint firstItem="Qnu-cd-McX" firstAttribute="width" secondItem="xnf-Iu-OEq" secondAttribute="width" id="HuL-PR-gUY"/>
+                                    <constraint firstAttribute="bottom" secondItem="Qnu-cd-McX" secondAttribute="bottom" id="OLr-rQ-EnS"/>
+                                    <constraint firstItem="xnf-Iu-OEq" firstAttribute="width" secondItem="cnX-NO-a0K" secondAttribute="width" id="WMT-kJ-hIw"/>
+                                    <constraint firstItem="xnf-Iu-OEq" firstAttribute="top" secondItem="cnX-NO-a0K" secondAttribute="top" id="aTP-39-EAH"/>
+                                    <constraint firstItem="Qnu-cd-McX" firstAttribute="leading" secondItem="cnX-NO-a0K" secondAttribute="leading" id="fCz-Ml-Vnj"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="i8V-ir-COL" userLabel="Stat">
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ngK-ft-fVb">
+                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="フォロー" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PHj-xv-Vc8">
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1qL-Po-6Tv" userLabel="FollowingButton">
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <state key="normal" title="100"/>
+                                        <connections>
+                                            <segue destination="6U7-mI-ayN" kind="push" id="Qkf-wJ-qOt"/>
+                                        </connections>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="フォロワー" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="knD-Z0-VR9" userLabel="フォロワー">
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mQj-hl-Bd0" userLabel="FollowersButton">
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <state key="normal" title="100"/>
+                                        <connections>
+                                            <segue destination="3df-Ct-SUt" kind="push" id="L9h-7o-iQe"/>
+                                        </connections>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5,100" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="siK-Xr-AGZ">
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="マイクロポスト" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sOD-8z-9kH">
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="ngK-ft-fVb" secondAttribute="trailingMargin" id="2cr-Ra-u14"/>
+                                    <constraint firstItem="knD-Z0-VR9" firstAttribute="centerY" secondItem="mQj-hl-Bd0" secondAttribute="centerY" id="3y4-B2-hnt"/>
+                                    <constraint firstItem="ngK-ft-fVb" firstAttribute="leading" secondItem="i8V-ir-COL" secondAttribute="leadingMargin" id="6an-mA-zEb"/>
+                                    <constraint firstItem="mQj-hl-Bd0" firstAttribute="top" secondItem="1qL-Po-6Tv" secondAttribute="bottom" id="Er3-ZS-wdf"/>
+                                    <constraint firstItem="PHj-xv-Vc8" firstAttribute="centerY" secondItem="1qL-Po-6Tv" secondAttribute="centerY" id="FeK-hl-dbZ"/>
+                                    <constraint firstItem="ngK-ft-fVb" firstAttribute="top" secondItem="i8V-ir-COL" secondAttribute="topMargin" id="IIf-jf-ADW"/>
+                                    <constraint firstItem="knD-Z0-VR9" firstAttribute="centerY" secondItem="mQj-hl-Bd0" secondAttribute="centerY" id="RVM-Ax-WsQ"/>
+                                    <constraint firstItem="1qL-Po-6Tv" firstAttribute="leading" secondItem="ngK-ft-fVb" secondAttribute="leading" id="XeR-RM-knQ"/>
+                                    <constraint firstItem="sOD-8z-9kH" firstAttribute="leading" secondItem="siK-Xr-AGZ" secondAttribute="trailing" constant="5" id="aKc-ha-76k"/>
+                                    <constraint firstItem="PHj-xv-Vc8" firstAttribute="leading" secondItem="1qL-Po-6Tv" secondAttribute="trailing" multiplier="1.1" id="cbT-w9-17c"/>
+                                    <constraint firstItem="sOD-8z-9kH" firstAttribute="centerY" secondItem="siK-Xr-AGZ" secondAttribute="centerY" id="fke-oa-LGK"/>
+                                    <constraint firstItem="1qL-Po-6Tv" firstAttribute="top" secondItem="ngK-ft-fVb" secondAttribute="bottom" id="hmw-hY-nbQ"/>
+                                    <constraint firstItem="knD-Z0-VR9" firstAttribute="leading" secondItem="mQj-hl-Bd0" secondAttribute="trailing" multiplier="1.1" id="igH-xk-AZx"/>
+                                    <constraint firstItem="mQj-hl-Bd0" firstAttribute="leading" secondItem="1qL-Po-6Tv" secondAttribute="leading" id="jQF-0O-B99"/>
+                                    <constraint firstItem="siK-Xr-AGZ" firstAttribute="leading" secondItem="mQj-hl-Bd0" secondAttribute="leading" constant="1" id="tli-u1-WqA"/>
+                                    <constraint firstItem="siK-Xr-AGZ" firstAttribute="top" secondItem="mQj-hl-Bd0" secondAttribute="bottom" constant="5" id="w2u-3M-h56"/>
+                                </constraints>
+                            </view>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QDi-Iy-IfD">
+                                <connections>
+                                    <segue destination="vdx-5Z-HXO" kind="embed" id="iVV-HS-cfW"/>
+                                </connections>
+                            </containerView>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="i8V-ir-COL" firstAttribute="height" secondItem="cnX-NO-a0K" secondAttribute="height" id="Boz-KK-y6j"/>
+                            <constraint firstItem="cnX-NO-a0K" firstAttribute="width" secondItem="0O8-3u-tgk" secondAttribute="width" multiplier="0.3" id="Dwf-B4-Yv3"/>
+                            <constraint firstItem="QDi-Iy-IfD" firstAttribute="leading" secondItem="0O8-3u-tgk" secondAttribute="leading" id="Hae-fH-e5j"/>
+                            <constraint firstItem="QDi-Iy-IfD" firstAttribute="top" secondItem="i8V-ir-COL" secondAttribute="bottom" id="LBW-Sn-fJq"/>
+                            <constraint firstAttribute="trailing" secondItem="QDi-Iy-IfD" secondAttribute="trailing" id="T8S-Qz-rKm"/>
+                            <constraint firstItem="i8V-ir-COL" firstAttribute="trailing" secondItem="0O8-3u-tgk" secondAttribute="trailingMargin" id="Um0-lE-qwZ"/>
+                            <constraint firstItem="cnX-NO-a0K" firstAttribute="top" secondItem="5Cw-4b-JHm" secondAttribute="bottom" constant="20" id="XY5-cp-7oa"/>
+                            <constraint firstItem="cnX-NO-a0K" firstAttribute="leading" secondItem="0O8-3u-tgk" secondAttribute="leadingMargin" id="eAw-dN-TP7"/>
+                            <constraint firstItem="i8V-ir-COL" firstAttribute="leading" secondItem="cnX-NO-a0K" secondAttribute="trailing" constant="10" id="eBJ-V0-QSl"/>
+                            <constraint firstItem="Z3F-Cp-n07" firstAttribute="top" secondItem="QDi-Iy-IfD" secondAttribute="bottom" id="gwj-iq-K7T"/>
+                            <constraint firstItem="i8V-ir-COL" firstAttribute="top" secondItem="cnX-NO-a0K" secondAttribute="top" id="wdh-rP-iIj"/>
+                        </constraints>
                     </view>
+                    <toolbarItems/>
                     <navigationItem key="navigationItem" title="プロフィール" id="LW0-wT-rEs"/>
-                    <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5Vj-pQ-VNI" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="272.80000000000001" y="-122.78860569715144"/>
+            <point key="canvasLocation" x="271.875" y="-124.64788732394366"/>
+        </scene>
+        <!--Following-->
+        <scene sceneID="zZf-6R-EpN">
+            <objects>
+                <viewControllerPlaceholder storyboardName="Following" id="6U7-mI-ayN" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="tTG-lt-jMe"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ezO-Lh-A90" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="993" y="-326"/>
+        </scene>
+        <!--Followers-->
+        <scene sceneID="5u5-Ek-KdT">
+            <objects>
+                <viewControllerPlaceholder storyboardName="Followers" id="3df-Ct-SUt" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="4ag-Dd-iFD"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="mFE-w4-EwG" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="993" y="12"/>
+        </scene>
+        <!--ProfileEdit-->
+        <scene sceneID="uFc-D4-ScO">
+            <objects>
+                <viewControllerPlaceholder storyboardName="ProfileEdit" id="Sgg-uN-ULc" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="imR-aG-V0F"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Pra-fj-hTe" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="993" y="133"/>
         </scene>
         <!--プロフィール-->
         <scene sceneID="0Oo-Sm-jhh">
@@ -43,6 +197,14 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="QBt-vO-vi1" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-727" y="-123"/>
+        </scene>
+        <!--Feed-->
+        <scene sceneID="DFI-Se-g9U">
+            <objects>
+                <viewControllerPlaceholder storyboardName="Feed" id="vdx-5Z-HXO" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="j6C-c8-zmA" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="272" y="288"/>
         </scene>
     </scenes>
 </document>

--- a/Turmeric/Storyboards/ProfileEdit.storyboard
+++ b/Turmeric/Storyboards/ProfileEdit.storyboard
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="KaW-Kz-MoV">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="BhT-0k-YUs">
+            <objects>
+                <viewController id="KaW-Kz-MoV" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="iGK-Dx-26H"/>
+                        <viewControllerLayoutGuide type="bottom" id="UOL-rD-zVx"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Dn8-Ei-Vxw">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="WJq-HX-Agi" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="441" y="-154"/>
+        </scene>
+    </scenes>
+</document>

--- a/TurmericUITests/ProfileUITests.swift
+++ b/TurmericUITests/ProfileUITests.swift
@@ -1,0 +1,41 @@
+//
+//  ProfileUITests.swift
+//  Turmeric
+//
+//  Created by usr0600437 on 2016/09/29.
+//  Copyright © 2016年 GMO Pepabo. All rights reserved.
+//
+
+import XCTest
+
+class ProfileUITests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testProfileLayout() {
+        //プロフィールページへ
+        let app = XCUIApplication()
+        app.launch()
+        app.tabBars.buttons["プロフィール"].tap()
+        
+        let profileEditButton           = app.buttons["profileEditButton"]
+        let profileFollowingCountButton = app.buttons["profileFollowingCountButton"]
+        let profileFollowersCountButton = app.buttons["profileFollowersCountButton"]
+        let profileImage                = app.images["profileImage"]
+        let profileMicropostsCountLabel = app.staticTexts["profileMicropostsCountLabel"]
+        
+        XCTAssert(profileEditButton.exists)
+        XCTAssert(profileFollowersCountButton.exists)
+        XCTAssert(profileFollowingCountButton.exists)
+        XCTAssert(profileMicropostsCountLabel.exists)
+        XCTAssert(profileImage.exists)
+        
+    }
+    
+}


### PR DESCRIPTION
_masterへのPRではありません_
APIのリクエストまで含めると大きくなりそうなのでPRを分離しました

やったこと
- [x] Profileページのレイアウト
  - [x] Profileの各ボタンから、遷移先StoryBoardへのsegue
  - [x] 遷移先StoryBoardの作成(Following, Followers, ProfileEdit)
  - [x] Profileのマイクロポスト一覧にViewContainerを追加
  - [x] Profileのマイクロポスト一覧のStoryBoardの作成(Feed)
- [x] ボタンを枠付きにするためのViewクラス
- [x] UITest
  - まだロジックがほぼないので要素があることを確かめるだけです
