### PR TITLE
UserモデルにgetMyUserメソッドを追加

### DIFF
--- a/Turmeric/Classes/Helpers/APIClient.swift
+++ b/Turmeric/Classes/Helpers/APIClient.swift
@@ -48,6 +48,7 @@ enum Endpoint {
     case UsersFollowers(Int)
     case UsersShow(Int)
     case UsersUpdate(Int)
+    case UsersMe
     
     //Microposts
     case MicropostsPost
@@ -66,6 +67,7 @@ enum Endpoint {
         case .UsersFollowers: return .get
         case .UsersShow: return .get
         case .UsersUpdate: return .patch
+        case .UsersMe: return .get
             
         case .MicropostsPost: return .post
         case .MicropostsShow: return .get
@@ -84,6 +86,7 @@ enum Endpoint {
         case .UsersFollowers(let userId): return "/api/users/\(userId)/followers"
         case .UsersShow(let userId): return "/api/users/\(userId)"
         case .UsersUpdate(let userId): return "/api/users/\(userId)"
+        case .UsersMe: return "/api/users/me"
             
         case .MicropostsPost: return "/api/microposts"
         case .MicropostsShow(let micropostId): return "/api/microposts/\(micropostId)"

--- a/Turmeric/Classes/Models/User.swift
+++ b/Turmeric/Classes/Models/User.swift
@@ -8,7 +8,12 @@ class User {
     let name: String
     let email: String
     
-    init(id: Int, name: String, email: String, token: String? = nil) {
+    var followingCount: Int?
+    var followersCount: Int?
+    var micropostsCount: Int?
+    var iconUrl: NSURL?
+    
+    init(id: Int, name: String, email: String) {
         self.id = id
         self.name = name
         self.email = email
@@ -18,10 +23,21 @@ class User {
         self.id   = json["user"]["id"].int!
         self.name = json["user"]["name"].string!
         self.email = json["user"]["email"].string!
+        
+        self.followingCount  = json["user"]["following_count"].intValue
+        self.followersCount  = json["user"]["followers_count"].intValue
+        self.micropostsCount = json["user"]["microposts_count"].intValue
+        self.iconUrl         = NSURL(string: json["user"]["icon_url"].stringValue)
     }
 
     static func createUser(parameters: Parameters, handler: @escaping ((User) -> Void)) {
         APIClient.request(endpoint: Endpoint.UsersCreate, parameters: parameters) { json in
+            handler(User(json: json))
+        }
+    }
+    
+    static func getMyUser(handler: @escaping ((User) -> Void)) {
+        APIClient.request(endpoint: Endpoint.UsersMe, parameters: [:]) { json in
             handler(User(json: json))
         }
     }

--- a/Turmeric/Classes/Models/User.swift
+++ b/Turmeric/Classes/Models/User.swift
@@ -8,15 +8,21 @@ class User {
     let name: String
     let email: String
     
-    var followingCount: Int?
-    var followersCount: Int?
-    var micropostsCount: Int?
-    var iconUrl: NSURL?
+    let followingCount: Int?
+    let followersCount: Int?
+    let micropostsCount: Int?
+    let iconUrl: NSURL?
     
     init(id: Int, name: String, email: String) {
         self.id = id
         self.name = name
         self.email = email
+        
+        self.followersCount  = nil
+        self.followingCount  = nil
+        self.micropostsCount = nil
+        
+        self.iconUrl = nil
     }
     
     init(json: JSON) {
@@ -30,7 +36,10 @@ class User {
         
         if let iconUrl = json["user"]["icon_url"].string {
             self.iconUrl = NSURL(string: iconUrl)
+        } else {
+            self.iconUrl = nil
         }
+        
     }
 
     static func createUser(parameters: Parameters, handler: @escaping ((User) -> Void)) {

--- a/Turmeric/Classes/Models/User.swift
+++ b/Turmeric/Classes/Models/User.swift
@@ -11,7 +11,7 @@ class User {
     let followingCount: Int?
     let followersCount: Int?
     let micropostsCount: Int?
-    let iconUrl: NSURL?
+    let iconURL: NSURL?
     
     init(id: Int, name: String, email: String) {
         self.id = id
@@ -22,7 +22,7 @@ class User {
         self.followingCount  = nil
         self.micropostsCount = nil
         
-        self.iconUrl = nil
+        self.iconURL = nil
     }
     
     init(json: JSON) {
@@ -34,10 +34,10 @@ class User {
         self.followersCount  = json["user"]["followers_count"].int
         self.micropostsCount = json["user"]["microposts_count"].int
         
-        if let iconUrl = json["user"]["icon_url"].string {
-            self.iconUrl = NSURL(string: iconUrl)
+        if let iconURL = json["user"]["icon_url"].string {
+            self.iconURL = NSURL(string: iconURL)
         } else {
-            self.iconUrl = nil
+            self.iconURL = nil
         }
         
     }

--- a/Turmeric/Classes/Models/User.swift
+++ b/Turmeric/Classes/Models/User.swift
@@ -24,10 +24,13 @@ class User {
         self.name = json["user"]["name"].string!
         self.email = json["user"]["email"].string!
         
-        self.followingCount  = json["user"]["following_count"].intValue
-        self.followersCount  = json["user"]["followers_count"].intValue
-        self.micropostsCount = json["user"]["microposts_count"].intValue
-        self.iconUrl         = NSURL(string: json["user"]["icon_url"].stringValue)
+        self.followingCount  = json["user"]["following_count"].int
+        self.followersCount  = json["user"]["followers_count"].int
+        self.micropostsCount = json["user"]["microposts_count"].int
+        
+        if let iconUrl = json["user"]["icon_url"].string {
+            self.iconUrl = NSURL(string: iconUrl)
+        }
     }
 
     static func createUser(parameters: Parameters, handler: @escaping ((User) -> Void)) {

--- a/TurmericTests/Models/UserTests.swift
+++ b/TurmericTests/Models/UserTests.swift
@@ -68,7 +68,7 @@ class UserTests: XCTestCase {
                 XCTAssertEqual(100, response.followingCount)
                 XCTAssertEqual(200, response.followersCount)
                 XCTAssertEqual(1000, response.micropostsCount)
-                XCTAssertEqual("https://example.com/example.jpg", response.iconUrl?.absoluteString)
+                XCTAssertEqual("https://example.com/example.jpg", response.iconURL?.absoluteString)
                 done()
             }
         }

--- a/TurmericTests/Models/UserTests.swift
+++ b/TurmericTests/Models/UserTests.swift
@@ -25,6 +25,14 @@ class UserTests: XCTestCase {
                 headers: nil
             )
         }
+        
+        stub(condition: isHost("currry.xyz") && isPath("/api/users/me") && isMethodGET()){_ in
+            return OHHTTPStubsResponse(
+                jsonObject: ["user" : ["id" : 1, "name" : "testUser", "email" : "test@test.com", "following_count": 100, "followers_count": 200, "microposts_count": 1000, "icon_url": "https://example.com/example.jpg"]],
+                statusCode: 200,
+                headers: nil
+            )
+        }
     }
 
     override func tearDown() {
@@ -52,7 +60,20 @@ class UserTests: XCTestCase {
             }
         }
     }
-
+    
+    func testUserMe() {
+        waitUntil { done in
+            User.getMyUser(){ response in
+                XCTAssertEqual("testUser", response.name)
+                XCTAssertEqual(100, response.followingCount)
+                XCTAssertEqual(200, response.followersCount)
+                XCTAssertEqual(1000, response.micropostsCount)
+                XCTAssertEqual("https://example.com/example.jpg", response.iconUrl?.absoluteString)
+                done()
+            }
+        }
+    }
+    
     func testUserLogin() {
         waitUntil { done in
             User.authenticate(parameters: ["user" : ["email" : "syuta_ogido@yahoo.co.jp", "password" : "testtest"]]) { response in


### PR DESCRIPTION
_※masterへのmergeじゃないよ_
APIに`GET /api/users/me`リクエストを投げて自分自身のユーザ情報を取得するメソッドを作成しました
- [x] Endpointの追加
- [x] UserにfollowersCount, followingCount, micropostsCount, iconUrlフィールドを追加
  - iconUrlはNSURLにしました
- [x] getMyUserメソッド
- [x] Userのイニシャライザに使わないtokenが含まれてそうだったので削除
