### PR TITLE
SwiftyJSONでの値取得時にNon-Optional Getterを使わないように修正

### DIFF
--- a/Turmeric/Classes/Models/User.swift
+++ b/Turmeric/Classes/Models/User.swift
@@ -4,9 +4,9 @@ import SwiftyJSON
 
 class User {
     
-    var id: Int
-    var name: String
-    var email: String
+    let id: Int
+    let name: String
+    let email: String
     
     init(id: Int, name: String, email: String, token: String? = nil) {
         self.id = id

--- a/Turmeric/Classes/Models/User.swift
+++ b/Turmeric/Classes/Models/User.swift
@@ -15,9 +15,9 @@ class User {
     }
     
     init(json: JSON) {
-        self.id   = json["user"]["id"].intValue
-        self.name = json["user"]["name"].stringValue
-        self.email = json["user"]["emain"].stringValue
+        self.id   = json["user"]["id"].int!
+        self.name = json["user"]["name"].string!
+        self.email = json["user"]["email"].string!
     }
 
     static func createUser(parameters: Parameters, handler: @escaping ((User) -> Void)) {

--- a/Turmeric/Classes/Models/User.swift
+++ b/Turmeric/Classes/Models/User.swift
@@ -28,7 +28,7 @@ class User {
     
     static func authenticate(parameters: Parameters, handler: @escaping (Any?) -> Void) {
         APIClient.request(endpoint: Endpoint.Auth, parameters: parameters) { json in
-            APIClient.token = json["token"].stringValue
+            APIClient.token = json["token"].string!
             handler(nil)
         }
     }

--- a/TurmericTests/Models/UserTests.swift
+++ b/TurmericTests/Models/UserTests.swift
@@ -12,7 +12,7 @@ class UserTests: XCTestCase {
 
         stub(condition: isHost("currry.xyz") && isPath("/api/users") && isMethodPOST()){_ in
             return OHHTTPStubsResponse(
-                jsonObject: ["user" : ["name" : "testUser"]],
+                jsonObject: ["user" : ["id": 1, "name" : "testUser", "email": "test@test.com"]],
                 statusCode: 200,
                 headers: nil
             )


### PR DESCRIPTION
SwiftyJSONの`xxxValue`メソッドは、Non-Optional Getterと言って「値がnilだったら代わりの値を返す」というヤバめの仕様だったので、JSONの値を取得するのに使わないことにします
(例えば`json["id"].intValue`みたいな取得をしようとした時、idが定義されていない場合は0を返します)

代わりに`int`メソッドみたいなOptional Getterで値を取得し、必須となる値は`!`をつけて強制アンラップします。
こうした場合、もしサーバ側が必須の値を返さない場合はクライアントがエラーを吐きます

このPRではOptionalGetterで値取得するように書き換えるのと、OptionalGetterを使っていなかったことによる見落としを修正します。
ついでに細かい修正も。
- [x] stubの`POST /users`のAPIがidとemailを返していなかったので追記しました
- [x] JSONからの値取得にOptional Getterを使います
- [x] typoを修正します
- [x] Userモデルのプロパティを`let`で宣言します
