### PR TITLE
APIによってJSONの構造が違うので、トップレベルに属性が来る方に共通化

### DIFF
--- a/Turmeric/Classes/Models/Micropost.swift
+++ b/Turmeric/Classes/Models/Micropost.swift
@@ -15,10 +15,10 @@ class Micropost {
     }
 
     init(json: JSON) {
-        self.id = json["micropost"]["id"].int!
-        self.userId = json["micropost"]["user_id"].int!
-        self.content = json["micropost"]["content"].string!
-        if let picture = json["micropost"]["picture"].string {
+        self.id = json["id"].int!
+        self.userId = json["user_id"].int!
+        self.content = json["content"].string!
+        if let picture = json["picture"].string {
             self.picture = NSURL(string: picture)
         } else {
             self.picture = nil

--- a/Turmeric/Classes/Models/User.swift
+++ b/Turmeric/Classes/Models/User.swift
@@ -3,29 +3,29 @@ import Alamofire
 import SwiftyJSON
 
 class User {
-    
+
     let id: Int
     let name: String
     let email: String
-    
+
     init(id: Int, name: String, email: String, token: String? = nil) {
         self.id = id
         self.name = name
         self.email = email
     }
-    
+
     init(json: JSON) {
-        self.id   = json["user"]["id"].int!
-        self.name = json["user"]["name"].string!
-        self.email = json["user"]["email"].string!
+        self.id = json["id"].int!
+        self.name = json["name"].string!
+        self.email = json["email"].string!
     }
 
     static func createUser(parameters: Parameters, handler: @escaping ((User) -> Void)) {
         APIClient.request(endpoint: Endpoint.UsersCreate, parameters: parameters) { json in
-            handler(User(json: json))
+            handler(User(json: json["user"]))
         }
     }
-    
+
     static func authenticate(parameters: Parameters, handler: @escaping (Any?) -> Void) {
         APIClient.request(endpoint: Endpoint.Auth, parameters: parameters) { json in
             APIClient.token = json["token"].string!


### PR DESCRIPTION
APIの仕様として、microposts#showなど単一の要素を返すレスポンスはmicropostの中にidやcontentが入っているが、feedのときは配列にidやcontentが直接入るという構造になっています。

フィードやリスト一覧で取得した配列をインスタンスにするときに不便なので、init()のjson引数はトップレベルに属性が来ると仮定して共通化します。

使うときはハンドラに渡すときに`handler(User(json: json["user"]))`などとすることになります。
