### PR TITLE
JSONファイルからスタブレスポンスを生成する

### DIFF
--- a/Turmeric.xcodeproj/project.pbxproj
+++ b/Turmeric.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		520654671D9E086500FD0BBE /* MicropostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520654661D9E086500FD0BBE /* MicropostTests.swift */; };
+		5206546C1D9E6E0900FD0BBE /* MicropostsShow.json in Resources */ = {isa = PBXBuildFile; fileRef = 5206546B1D9E6E0900FD0BBE /* MicropostsShow.json */; };
 		521173B61D9A504800DDA29E /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 521173B51D9A504800DDA29E /* OHHTTPStubs.framework */; };
 		521173B71D9A6D0000DDA29E /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 521173B51D9A504800DDA29E /* OHHTTPStubs.framework */; };
 		521173B91D9A79AB00DDA29E /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 521173B81D9A79AB00DDA29E /* Nimble.framework */; };
@@ -52,6 +53,7 @@
 
 /* Begin PBXFileReference section */
 		520654661D9E086500FD0BBE /* MicropostTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MicropostTests.swift; sourceTree = "<group>"; };
+		5206546B1D9E6E0900FD0BBE /* MicropostsShow.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MicropostsShow.json; sourceTree = "<group>"; };
 		521173B51D9A504800DDA29E /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		521173B81D9A79AB00DDA29E /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
 		522C8AA61D9CBC2C00E17D4C /* List.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = List.swift; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 		520654681D9E515E00FD0BBE /* Fixtures */ = {
 			isa = PBXGroup;
 			children = (
+				5206546B1D9E6E0900FD0BBE /* MicropostsShow.json */,
 			);
 			path = Fixtures;
 			sourceTree = "<group>";
@@ -416,6 +419,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5206546C1D9E6E0900FD0BBE /* MicropostsShow.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Turmeric.xcodeproj/project.pbxproj
+++ b/Turmeric.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		52B1C6E41D98EFD2002AB83B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 52B1C6E31D98EFD2002AB83B /* Assets.xcassets */; };
 		52B1C6FD1D98EFD2002AB83B /* TurmericUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B1C6FC1D98EFD2002AB83B /* TurmericUITests.swift */; };
 		52D6E7C11D9CE22900A0A564 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52D6E7C01D9CE22900A0A564 /* UserTests.swift */; };
+		52F6CAF11DA2069800C1C9CC /* MicropostsShow_withPicture.json in Resources */ = {isa = PBXBuildFile; fileRef = 52F6CAF01DA2069800C1C9CC /* MicropostsShow_withPicture.json */; };
 		7231C3D91D9A0BA90086D60F /* Mention.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7231C3D81D9A0BA90086D60F /* Mention.storyboard */; };
 		724DB9131D9926FB00008C25 /* Home.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9121D9926FB00008C25 /* Home.storyboard */; };
 		724DB9151D99271B00008C25 /* Post.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9141D99271B00008C25 /* Post.storyboard */; };
@@ -77,6 +78,7 @@
 		52B1C6FC1D98EFD2002AB83B /* TurmericUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurmericUITests.swift; sourceTree = "<group>"; };
 		52B1C6FE1D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		52D6E7C01D9CE22900A0A564 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserTests.swift; sourceTree = "<group>"; };
+		52F6CAF01DA2069800C1C9CC /* MicropostsShow_withPicture.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MicropostsShow_withPicture.json; sourceTree = "<group>"; };
 		7231C3D81D9A0BA90086D60F /* Mention.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Mention.storyboard; sourceTree = "<group>"; };
 		724DB9121D9926FB00008C25 /* Home.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Home.storyboard; sourceTree = "<group>"; };
 		724DB9141D99271B00008C25 /* Post.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Post.storyboard; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 			isa = PBXGroup;
 			children = (
 				5206546B1D9E6E0900FD0BBE /* MicropostsShow.json */,
+				52F6CAF01DA2069800C1C9CC /* MicropostsShow_withPicture.json */,
 			);
 			path = Fixtures;
 			sourceTree = "<group>";
@@ -419,6 +422,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				52F6CAF11DA2069800C1C9CC /* MicropostsShow_withPicture.json in Resources */,
 				5206546C1D9E6E0900FD0BBE /* MicropostsShow.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Turmeric.xcodeproj/project.pbxproj
+++ b/Turmeric.xcodeproj/project.pbxproj
@@ -113,6 +113,13 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		520654681D9E515E00FD0BBE /* Fixtures */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Fixtures;
+			sourceTree = "<group>";
+		};
 		520C41C21D9CDC66004C439C /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
@@ -264,6 +271,7 @@
 		52B1C6F01D98EFD2002AB83B /* TurmericTests */ = {
 			isa = PBXGroup;
 			children = (
+				520654681D9E515E00FD0BBE /* Fixtures */,
 				520C41C21D9CDC66004C439C /* Controllers */,
 				520C41C31D9CDC66004C439C /* Helpers */,
 				520C41C41D9CDC66004C439C /* Models */,

--- a/TurmericTests/Fixtures/MicropostsShow.json
+++ b/TurmericTests/Fixtures/MicropostsShow.json
@@ -5,6 +5,6 @@
         "user_id": 1,
         "created_at": "2016-09-30T09:41:24.000Z",
         "updated_at": "2016-09-30T09:51:25.000Z",
-        "picture": null
+        "picture": "https://example.com/picture.jpg"
     }
 }

--- a/TurmericTests/Fixtures/MicropostsShow.json
+++ b/TurmericTests/Fixtures/MicropostsShow.json
@@ -5,6 +5,6 @@
         "user_id": 1,
         "created_at": "2016-09-30T09:41:24.000Z",
         "updated_at": "2016-09-30T09:51:25.000Z",
-        "picture": "https://example.com/picture.jpg"
+        "picture": null
     }
 }

--- a/TurmericTests/Fixtures/MicropostsShow.json
+++ b/TurmericTests/Fixtures/MicropostsShow.json
@@ -1,0 +1,10 @@
+{
+    "micropost": {
+        "id": 100,
+        "content": "I just ate an orange!",
+        "user_id": 1,
+        "created_at": "2016-09-30T09:41:24.000Z",
+        "updated_at": "2016-09-30T09:51:25.000Z",
+        "picture": null
+    }
+}

--- a/TurmericTests/Fixtures/MicropostsShow_withPicture.json
+++ b/TurmericTests/Fixtures/MicropostsShow_withPicture.json
@@ -1,0 +1,10 @@
+{
+    "micropost": {
+        "id": 101,
+        "content": "With picture",
+        "user_id": 2,
+        "created_at": "2016-10-03T12:41:24.000Z",
+        "updated_at": "2016-10-03T12:51:25.000Z",
+        "picture": "https://example.com/picture.jpg"
+    }
+}

--- a/TurmericTests/Models/MicropostTests.swift
+++ b/TurmericTests/Models/MicropostTests.swift
@@ -21,6 +21,15 @@ class MicropostTests: XCTestCase {
                 XCTAssertEqual(100, response.id)
                 XCTAssertEqual(1, response.userId)
                 XCTAssertEqual("I just ate an orange!", response.content)
+                XCTAssertNil(response.picture)
+                done()
+            }
+        }
+        waitUntil { done in
+            Micropost.getMicropost(id: 101) { response in
+                XCTAssertEqual(101, response.id)
+                XCTAssertEqual(2, response.userId)
+                XCTAssertEqual("With picture", response.content)
                 XCTAssertEqual("https://example.com/picture.jpg", response.picture?.absoluteString)
                 done()
             }

--- a/TurmericTests/Models/MicropostTests.swift
+++ b/TurmericTests/Models/MicropostTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import OHHTTPStubs
 import Nimble
 
 @testable import Turmeric
@@ -7,12 +6,12 @@ import Nimble
 class MicropostTests: XCTestCase {
     override func setUp() {
         super.setUp()
-        enableHTTPStubsResponse()
+        enableHTTPStubs()
     }
 
     override func tearDown() {
         super.tearDown()
-        OHHTTPStubs.removeAllStubs()
+        disableHTTPStubs()
     }
 
     func testGetMicropost() {

--- a/TurmericTests/Models/MicropostTests.swift
+++ b/TurmericTests/Models/MicropostTests.swift
@@ -7,21 +7,7 @@ import Nimble
 class MicropostTests: XCTestCase {
     override func setUp() {
         super.setUp()
-
-        stub(condition: isHost("currry.xyz") && isPath("/api/microposts/100") && isMethodGET()){_ in
-            return OHHTTPStubsResponse(
-                jsonObject: ["micropost" : ["id" : 100, "user_id" : 1, "content" : "testContent", "picture" : "https://example.com/picture.jpg"]],
-                statusCode: 200,
-                headers: nil
-            )
-        }
-        stub(condition: isHost("currry.xyz") && isPath("/api/microposts/101") && isMethodGET()){_ in
-            return OHHTTPStubsResponse(
-                jsonObject: ["micropost" : ["id" : 101, "user_id" : 2, "content" : "testContent2"]],
-                statusCode: 200,
-                headers: nil
-            )
-        }
+        enableHTTPStubsResponse()
     }
 
     override func tearDown() {
@@ -34,17 +20,8 @@ class MicropostTests: XCTestCase {
             Micropost.getMicropost(id: 100) { response in
                 XCTAssertEqual(100, response.id)
                 XCTAssertEqual(1, response.userId)
-                XCTAssertEqual("testContent", response.content)
+                XCTAssertEqual("I just ate an orange!", response.content)
                 XCTAssertEqual("https://example.com/picture.jpg", response.picture?.absoluteString)
-                done()
-            }
-        }
-        waitUntil { done in
-            Micropost.getMicropost(id: 101) { response in
-                XCTAssertEqual(101, response.id)
-                XCTAssertEqual(2, response.userId)
-                XCTAssertEqual("testContent2", response.content)
-                XCTAssertNil(response.picture)
                 done()
             }
         }

--- a/TurmericTests/TestHelpers.swift
+++ b/TurmericTests/TestHelpers.swift
@@ -24,4 +24,11 @@ func enableHTTPStubsResponse() {
             headers: ["Content-Type": "application/json"]
         )
     }
+    stub(condition: isHost("currry.xyz") && isPath("/api/microposts/101") && isMethodGET()){_ in
+        return OHHTTPStubsResponse(
+            fileAtPath: OHPathForFileInBundle("MicropostsShow_withPicture.json", Bundle.init(identifier: "com.pepabo.training.TurmericTests")!)!,
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"]
+        )
+    }
 }

--- a/TurmericTests/TestHelpers.swift
+++ b/TurmericTests/TestHelpers.swift
@@ -16,7 +16,7 @@ func logout() {
     APIClient.token = nil
 }
 
-func enableHTTPStubsResponse() {
+func enableHTTPStubs() {
     stub(condition: isHost("currry.xyz") && isPath("/api/microposts/100") && isMethodGET()){_ in
         return OHHTTPStubsResponse(
             fileAtPath: stubFilePath(name: "MicropostsShow.json"),
@@ -31,6 +31,11 @@ func enableHTTPStubsResponse() {
             headers: ["Content-Type": "application/json"]
         )
     }
+}
+
+func disableHTTPStubs() {
+    // "Expression resolves to an unused function"と言われるため
+    _ = OHHTTPStubs.removeAllStubs
 }
 
 private func stubFilePath(name: String) -> String {

--- a/TurmericTests/TestHelpers.swift
+++ b/TurmericTests/TestHelpers.swift
@@ -19,16 +19,20 @@ func logout() {
 func enableHTTPStubsResponse() {
     stub(condition: isHost("currry.xyz") && isPath("/api/microposts/100") && isMethodGET()){_ in
         return OHHTTPStubsResponse(
-            fileAtPath: OHPathForFileInBundle("MicropostsShow.json", Bundle.init(identifier: "com.pepabo.training.TurmericTests")!)!,
+            fileAtPath: stubFilePath(name: "MicropostsShow.json"),
             statusCode: 200,
             headers: ["Content-Type": "application/json"]
         )
     }
     stub(condition: isHost("currry.xyz") && isPath("/api/microposts/101") && isMethodGET()){_ in
         return OHHTTPStubsResponse(
-            fileAtPath: OHPathForFileInBundle("MicropostsShow_withPicture.json", Bundle.init(identifier: "com.pepabo.training.TurmericTests")!)!,
+            fileAtPath: stubFilePath(name: "MicropostsShow_withPicture.json"),
             statusCode: 200,
             headers: ["Content-Type": "application/json"]
         )
     }
+}
+
+private func stubFilePath(name: String) -> String {
+    return OHPathForFileInBundle(name, Bundle.init(identifier: "com.pepabo.training.TurmericTests")!)!
 }

--- a/TurmericTests/TestHelpers.swift
+++ b/TurmericTests/TestHelpers.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OHHTTPStubs
 import Nimble
 
 @testable import Turmeric
@@ -13,4 +14,14 @@ func login(){
 
 func logout() {
     APIClient.token = nil
+}
+
+func enableHTTPStubsResponse() {
+    stub(condition: isHost("currry.xyz") && isPath("/api/microposts/100") && isMethodGET()){_ in
+        return OHHTTPStubsResponse(
+            fileAtPath: OHPathForFileInBundle("MicropostsShow.json", Bundle.init(identifier: "com.pepabo.training.TurmericTests")!)!,
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"]
+        )
+    }
 }


### PR DESCRIPTION
JSONファイルからスタブを生成するようにしてスタブ書くのを楽にし、さらにヘルパーメソッドにまとめてテストファイルの見通しを良くします。

このPRではMicropostsのみ行います（Userモデルは別PRで）
