### PR TITLE
Stubをアプリケーションhelperにする

### DIFF
--- a/Turmeric.xcodeproj/project.pbxproj
+++ b/Turmeric.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		724DB9151D99271B00008C25 /* Post.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9141D99271B00008C25 /* Post.storyboard */; };
 		724DB9171D99274A00008C25 /* Profile.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9161D99274A00008C25 /* Profile.storyboard */; };
 		724DB9191D99275300008C25 /* Lists.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9181D99275300008C25 /* Lists.storyboard */; };
+		725B13131DA2450C00A12006 /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725B13121DA2450C00A12006 /* Stub.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -94,6 +95,7 @@
 		724DB9141D99271B00008C25 /* Post.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Post.storyboard; sourceTree = "<group>"; };
 		724DB9161D99274A00008C25 /* Profile.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Profile.storyboard; sourceTree = "<group>"; };
 		724DB9181D99275300008C25 /* Lists.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Lists.storyboard; sourceTree = "<group>"; };
+		725B13121DA2450C00A12006 /* Stub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stub.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -200,6 +202,7 @@
 			isa = PBXGroup;
 			children = (
 				52685A261D990E4400FEC0A7 /* APIClient.swift */,
+				725B13121DA2450C00A12006 /* Stub.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -500,6 +503,7 @@
 				52A635D31D9CD9FE00646119 /* Micropost.swift in Sources */,
 				5232599F1D9A0D8100476111 /* User.swift in Sources */,
 				5242ABF81D98F1BE0095D4F4 /* ViewController.swift in Sources */,
+				725B13131DA2450C00A12006 /* Stub.swift in Sources */,
 				52B1C6DD1D98EFD2002AB83B /* AppDelegate.swift in Sources */,
 				522C8AA71D9CBC2C00E17D4C /* List.swift in Sources */,
 				52685A271D990E4400FEC0A7 /* APIClient.swift in Sources */,

--- a/Turmeric.xcodeproj/xcshareddata/xcschemes/Turmeric.xcscheme
+++ b/Turmeric.xcodeproj/xcshareddata/xcschemes/Turmeric.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Test"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">

--- a/Turmeric/AppDelegate.swift
+++ b/Turmeric/AppDelegate.swift
@@ -22,6 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         #elseif TEST
             // for test setting
             print("launch test mode")
+            enableHTTPStubs()
         #endif
         
         #if DEBUG || TEST

--- a/Turmeric/AppDelegate.swift
+++ b/Turmeric/AppDelegate.swift
@@ -23,20 +23,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             // for test setting
             print("launch test mode")
             enableHTTPStubs()
-        #endif
-        
-        #if DEBUG || TEST
-            User.authenticate(parameters: ["user" : ["email" : "syuta_ogido@yahoo.co.jp", "password" : "testtest"]]) { response in
-                print("logged in")
-            }
-            
-            stub(condition: isHost("currry.xyz") && isPath("/api/users") && isMethodPOST()){_ in
-                return OHHTTPStubsResponse(
-                    jsonObject: ["user" : ["id": 1, "name" : "ogidow", "email": "syuta_ogido@yahoo.co.jp"]],
-                    statusCode: 200,
-                    headers: nil
-                )
-            }
             
             stub(condition: isHost("currry.xyz") && isPath("/api/auth") && isMethodPOST()){_ in
                 return OHHTTPStubsResponse(
@@ -57,6 +43,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     statusCode: 200,
                     headers: nil
                 )
+            }
+        #endif
+        
+        #if DEBUG || TEST
+            User.authenticate(parameters: ["user" : ["email" : "syuta_ogido@yahoo.co.jp", "password" : "testtest"]]) { response in
+                print("logged in")
             }
         #endif
         return true

--- a/Turmeric/Classes/Helpers/Stub.swift
+++ b/Turmeric/Classes/Helpers/Stub.swift
@@ -1,0 +1,36 @@
+//
+//  Stub.swift
+//  Turmeric
+//
+//  Created by usr0600437 on 2016/10/03.
+//  Copyright © 2016年 GMO Pepabo. All rights reserved.
+//
+
+import Foundation
+import OHHTTPStubs
+
+func enableHTTPStubs() {
+    stub(condition: isHost("currry.xyz") && isPath("/api/microposts/100") && isMethodGET()){_ in
+        return OHHTTPStubsResponse(
+            fileAtPath: stubFilePath(name: "MicropostsShow.json"),
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"]
+        )
+    }
+    stub(condition: isHost("currry.xyz") && isPath("/api/microposts/101") && isMethodGET()){_ in
+        return OHHTTPStubsResponse(
+            fileAtPath: stubFilePath(name: "MicropostsShow_withPicture.json"),
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"]
+        )
+    }
+}
+
+func disableHTTPStubs() {
+    // "Expression resolves to an unused function"と言われるため
+    _ = OHHTTPStubs.removeAllStubs
+}
+
+private func stubFilePath(name: String) -> String {
+    return OHPathForFileInBundle(name, Bundle.init(identifier: "com.pepabo.training.TurmericTests")!)!
+}

--- a/Turmeric/Classes/Helpers/Stub.swift
+++ b/Turmeric/Classes/Helpers/Stub.swift
@@ -24,6 +24,15 @@ func enableHTTPStubs() {
             headers: ["Content-Type": "application/json"]
         )
     }
+    
+    // User
+    stub(condition: isHost("currry.xyz") && isPath("/api/users") && isMethodPOST()){_ in
+        return OHHTTPStubsResponse(
+            fileAtPath: stubFilePath(name: "UsersCreate.json"),
+            statusCode: 201,
+            headers: ["Content-Type": "application/json"]
+        )
+    }
 }
 
 func disableHTTPStubs() {

--- a/TurmericTests/TestHelpers.swift
+++ b/TurmericTests/TestHelpers.swift
@@ -15,39 +15,3 @@ func login(){
 func logout() {
     APIClient.token = nil
 }
-
-func enableHTTPStubs() {
-    // Micropost
-    stub(condition: isHost("currry.xyz") && isPath("/api/microposts/100") && isMethodGET()){_ in
-        return OHHTTPStubsResponse(
-            fileAtPath: stubFilePath(name: "MicropostsShow.json"),
-            statusCode: 200,
-            headers: ["Content-Type": "application/json"]
-        )
-    }
-    stub(condition: isHost("currry.xyz") && isPath("/api/microposts/101") && isMethodGET()){_ in
-        return OHHTTPStubsResponse(
-            fileAtPath: stubFilePath(name: "MicropostsShow_withPicture.json"),
-            statusCode: 200,
-            headers: ["Content-Type": "application/json"]
-        )
-    }
-
-    // User
-    stub(condition: isHost("currry.xyz") && isPath("/api/users") && isMethodPOST()){_ in
-        return OHHTTPStubsResponse(
-            fileAtPath: stubFilePath(name: "UsersCreate.json"),
-            statusCode: 201,
-            headers: ["Content-Type": "application/json"]
-        )
-    }
-}
-
-func disableHTTPStubs() {
-    // "Expression resolves to an unused function"と言われるため
-    _ = OHHTTPStubs.removeAllStubs
-}
-
-private func stubFilePath(name: String) -> String {
-    return OHPathForFileInBundle(name, Bundle.init(identifier: "com.pepabo.training.TurmericTests")!)!
-}


### PR DESCRIPTION
OHHTTPstubによるUIテストを行おうとした場合、アプリケーションそのものにStubを組み込む必要があるので、テストヘルパーではなくアプリケーションヘルパーにします。

stubに読み込むJSONファイル自体はtestのfixtureです
