### PR TITLE
Carthageディレクトリごとgitignoreしてgit cleanで消滅するのを抑止する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,9 +52,7 @@ playground.xcworkspace
 # Carthage
 #
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
-Carthage/Checkouts
-
-Carthage/Build
+Carthage/
 
 # fastlane
 #


### PR DESCRIPTION
git cleanでCarthageディレクトリを吹き飛ばしてビルドし直しになる事故（2回目）
が起きたので、もう悲しみに暮れないようにgitignoreの構文を変えます

このgitignoreのサンプルではCarthage/Buildをignoreするようになっていたのですが、Carthage/Checkoutsも無視していいのでCarthageディレクトリごとignoreするようにしました

-xオプションが指定されていない限り、gitignoreで指定されたファイル・ディレクトリは削除対象になりません。
https://gotohayato.com/content/104
