### PR TITLE
投稿ページのレイアウト

### DIFF
--- a/Turmeric.xcodeproj/project.pbxproj
+++ b/Turmeric.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		724DB9191D99275300008C25 /* Lists.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9181D99275300008C25 /* Lists.storyboard */; };
 		725B13131DA2450C00A12006 /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725B13121DA2450C00A12006 /* Stub.swift */; };
 		725B131A1DA39AFC00A12006 /* PostKeyboardToolbar.xib in Resources */ = {isa = PBXBuildFile; fileRef = 725B13191DA39AFC00A12006 /* PostKeyboardToolbar.xib */; };
+		72B14FF71DA39D79005E7523 /* PostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B14FF61DA39D79005E7523 /* PostViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,19 +82,19 @@
 
 /* Begin PBXFileReference section */
 		520654661D9E086500FD0BBE /* MicropostTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MicropostTests.swift; sourceTree = "<group>"; };
-		521173B51D9A504800DDA29E /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		5221F3541DA35B9100719B90 /* Auth.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Auth.json; sourceTree = "<group>"; };
+		521173B51D9A504800DDA29E /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		521173B81D9A79AB00DDA29E /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
-		5222F5A61DA34A0F00990E8E /* ListsMembers.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ListsMembers.json; sourceTree = "<group>"; };
 		521BC0A81DA3B05300A83893 /* ListEdit.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = ListEdit.storyboard; sourceTree = "<group>"; };
 		521BC0AA1DA3B0D600A83893 /* ListEditViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListEditViewController.swift; sourceTree = "<group>"; };
+		5222F5A61DA34A0F00990E8E /* ListsMembers.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ListsMembers.json; sourceTree = "<group>"; };
 		5222F5A71DA34A0F00990E8E /* ListsShow.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ListsShow.json; sourceTree = "<group>"; };
 		5222F5A81DA34A0F00990E8E /* MicropostsShow.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MicropostsShow.json; sourceTree = "<group>"; };
 		5222F5A91DA34A0F00990E8E /* MicropostsShow_withPicture.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MicropostsShow_withPicture.json; sourceTree = "<group>"; };
-		5222F5AA1DA34A0F00990E8E /* MyLists.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MyLists.json; sourceTree = "<group>"; };
 		521BC0A21DA3527000A83893 /* MembersCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MembersCell.swift; sourceTree = "<group>"; };
 		521BC0A31DA3527000A83893 /* MembersCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MembersCell.xib; sourceTree = "<group>"; };
 		521BC0A61DA3971200A83893 /* ListDetailUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListDetailUITests.swift; sourceTree = "<group>"; };
+		5222F5AA1DA34A0F00990E8E /* MyLists.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MyLists.json; sourceTree = "<group>"; };
 		5222F5AB1DA34A0F00990E8E /* UsersCreate.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UsersCreate.json; sourceTree = "<group>"; };
 		522C8AA61D9CBC2C00E17D4C /* List.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = List.swift; sourceTree = "<group>"; };
 		522C8AAE1D9D1D3F00E17D4C /* TestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
@@ -103,9 +104,9 @@
 		5242ABFA1D98F1CB0095D4F4 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		525B70781D98F985004D72BD /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
 		525B70791D98F985004D72BD /* AlamofireImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AlamofireImage.framework; path = Carthage/Build/iOS/AlamofireImage.framework; sourceTree = "<group>"; };
-		525B707A1D98F985004D72BD /* SwiftyJSON.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyJSON.framework; path = Carthage/Build/iOS/SwiftyJSON.framework; sourceTree = "<group>"; };
 		526B149D1DA4A21F00BDAAFA /* MembersDeleteCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MembersDeleteCell.swift; sourceTree = "<group>"; };
 		526B149E1DA4A21F00BDAAFA /* MembersDeleteCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MembersDeleteCell.xib; sourceTree = "<group>"; };
+		525B707A1D98F985004D72BD /* SwiftyJSON.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyJSON.framework; path = Carthage/Build/iOS/SwiftyJSON.framework; sourceTree = "<group>"; };
 		52685A261D990E4400FEC0A7 /* APIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		52A15F281DA1FABA009D4525 /* ListUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListUITests.swift; sourceTree = "<group>"; };
 		52A15F371DA24923009D4525 /* ListTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListTests.swift; sourceTree = "<group>"; };
@@ -117,7 +118,6 @@
 		52B1C6DC1D98EFD2002AB83B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		52B1C6E31D98EFD2002AB83B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		52B1C6E81D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		52B1C6ED1D98EFD2002AB83B /* TurmericTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TurmericTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		725B13171DA35C4600A12006 /* Me.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Me.json; sourceTree = "<group>"; };
 		72C0D6DF1D9BB50600D47723 /* Feed.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Feed.storyboard; sourceTree = "<group>"; };
 		72C0D6E11D9BB54A00D47723 /* Following.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Following.storyboard; sourceTree = "<group>"; };
@@ -126,10 +126,11 @@
 		72C0D6E71D9BBC9000D47723 /* LinedButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinedButton.swift; sourceTree = "<group>"; };
 		72C0D6EB1D9CBBE200D47723 /* ProfileUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileUITests.swift; sourceTree = "<group>"; };
 		72C0D6ED1D9D106000D47723 /* ProfileViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
+		52B1C6ED1D98EFD2002AB83B /* TurmericTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TurmericTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		52B1C6F31D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		52B1C6F81D98EFD2002AB83B /* TurmericUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TurmericUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		52B1C6FE1D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		52F1EF4C1DA39BD1009B4327 /* MyFeed.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MyFeed.json; sourceTree = "<group>"; };
+		52B1C6FE1D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		52D6E7C01D9CE22900A0A564 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserTests.swift; sourceTree = "<group>"; };
 		7231C3D81D9A0BA90086D60F /* Mention.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Mention.storyboard; sourceTree = "<group>"; };
 		724DB9121D9926FB00008C25 /* Home.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Home.storyboard; sourceTree = "<group>"; };
@@ -138,6 +139,7 @@
 		724DB9181D99275300008C25 /* Lists.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Lists.storyboard; sourceTree = "<group>"; };
 		725B13121DA2450C00A12006 /* Stub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stub.swift; sourceTree = "<group>"; };
 		725B13191DA39AFC00A12006 /* PostKeyboardToolbar.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PostKeyboardToolbar.xib; sourceTree = "<group>"; };
+		72B14FF61DA39D79005E7523 /* PostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -217,6 +219,7 @@
 				52A44A881D9E512600DE76FD /* ListDetailViewController.swift */,
 				72C0D6ED1D9D106000D47723 /* ProfileViewController.swift */,
 				521BC0AA1DA3B0D600A83893 /* ListEditViewController.swift */,
+				72B14FF61DA39D79005E7523 /* PostViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -551,10 +554,11 @@
 				5232599F1D9A0D8100476111 /* User.swift in Sources */,
 				526B149F1DA4A21F00BDAAFA /* MembersDeleteCell.swift in Sources */,
 				5242ABF81D98F1BE0095D4F4 /* ViewController.swift in Sources */,
-				725B13131DA2450C00A12006 /* Stub.swift in Sources */,
+				72B14FF71DA39D79005E7523 /* PostViewController.swift in Sources */,
 				72C0D6EE1D9D106000D47723 /* ProfileViewController.swift in Sources */,
-				52B1C6DD1D98EFD2002AB83B /* AppDelegate.swift in Sources */,
+				725B13131DA2450C00A12006 /* Stub.swift in Sources */,
 				521BC0AB1DA3B0D600A83893 /* ListEditViewController.swift in Sources */,
+				52B1C6DD1D98EFD2002AB83B /* AppDelegate.swift in Sources */,
 				522C8AA71D9CBC2C00E17D4C /* List.swift in Sources */,
 				52685A271D990E4400FEC0A7 /* APIClient.swift in Sources */,
 				52A44A7B1D9E304500DE76FD /* ListViewController.swift in Sources */,

--- a/Turmeric.xcodeproj/project.pbxproj
+++ b/Turmeric.xcodeproj/project.pbxproj
@@ -11,18 +11,18 @@
 		521173B61D9A504800DDA29E /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 521173B51D9A504800DDA29E /* OHHTTPStubs.framework */; };
 		521173B71D9A6D0000DDA29E /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 521173B51D9A504800DDA29E /* OHHTTPStubs.framework */; };
 		521173B91D9A79AB00DDA29E /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 521173B81D9A79AB00DDA29E /* Nimble.framework */; };
-		521BC0A41DA3527000A83893 /* MembersCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521BC0A21DA3527000A83893 /* MembersCell.swift */; };
-		521BC0A51DA3527000A83893 /* MembersCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 521BC0A31DA3527000A83893 /* MembersCell.xib */; };
-		521BC0A71DA3971200A83893 /* ListDetailUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521BC0A61DA3971200A83893 /* ListDetailUITests.swift */; };
-		521BC0A91DA3B05300A83893 /* ListEdit.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 521BC0A81DA3B05300A83893 /* ListEdit.storyboard */; };
-		521BC0AB1DA3B0D600A83893 /* ListEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521BC0AA1DA3B0D600A83893 /* ListEditViewController.swift */; };
 		5221F3551DA35B9100719B90 /* Auth.json in Resources */ = {isa = PBXBuildFile; fileRef = 5221F3541DA35B9100719B90 /* Auth.json */; };
 		5222F5AC1DA34A0F00990E8E /* ListsMembers.json in Resources */ = {isa = PBXBuildFile; fileRef = 5222F5A61DA34A0F00990E8E /* ListsMembers.json */; };
 		5222F5AD1DA34A0F00990E8E /* ListsShow.json in Resources */ = {isa = PBXBuildFile; fileRef = 5222F5A71DA34A0F00990E8E /* ListsShow.json */; };
+		521BC0A91DA3B05300A83893 /* ListEdit.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 521BC0A81DA3B05300A83893 /* ListEdit.storyboard */; };
+		521BC0AB1DA3B0D600A83893 /* ListEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521BC0AA1DA3B0D600A83893 /* ListEditViewController.swift */; };
 		5222F5AE1DA34A0F00990E8E /* MicropostsShow.json in Resources */ = {isa = PBXBuildFile; fileRef = 5222F5A81DA34A0F00990E8E /* MicropostsShow.json */; };
 		5222F5AF1DA34A0F00990E8E /* MicropostsShow_withPicture.json in Resources */ = {isa = PBXBuildFile; fileRef = 5222F5A91DA34A0F00990E8E /* MicropostsShow_withPicture.json */; };
 		5222F5B01DA34A0F00990E8E /* MyLists.json in Resources */ = {isa = PBXBuildFile; fileRef = 5222F5AA1DA34A0F00990E8E /* MyLists.json */; };
 		5222F5B11DA34A0F00990E8E /* UsersCreate.json in Resources */ = {isa = PBXBuildFile; fileRef = 5222F5AB1DA34A0F00990E8E /* UsersCreate.json */; };
+		521BC0A41DA3527000A83893 /* MembersCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521BC0A21DA3527000A83893 /* MembersCell.swift */; };
+		521BC0A51DA3527000A83893 /* MembersCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 521BC0A31DA3527000A83893 /* MembersCell.xib */; };
+		521BC0A71DA3971200A83893 /* ListDetailUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521BC0A61DA3971200A83893 /* ListDetailUITests.swift */; };
 		522C8AA71D9CBC2C00E17D4C /* List.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522C8AA61D9CBC2C00E17D4C /* List.swift */; };
 		522C8AAF1D9D1D3F00E17D4C /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522C8AAE1D9D1D3F00E17D4C /* TestHelpers.swift */; };
 		5232599F1D9A0D8100476111 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5232599E1D9A0D8100476111 /* User.swift */; };
@@ -59,6 +59,7 @@
 		724DB9171D99274A00008C25 /* Profile.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9161D99274A00008C25 /* Profile.storyboard */; };
 		724DB9191D99275300008C25 /* Lists.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9181D99275300008C25 /* Lists.storyboard */; };
 		725B13131DA2450C00A12006 /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725B13121DA2450C00A12006 /* Stub.swift */; };
+		725B131A1DA39AFC00A12006 /* PostKeyboardToolbar.xib in Resources */ = {isa = PBXBuildFile; fileRef = 725B13191DA39AFC00A12006 /* PostKeyboardToolbar.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,18 +82,18 @@
 /* Begin PBXFileReference section */
 		520654661D9E086500FD0BBE /* MicropostTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MicropostTests.swift; sourceTree = "<group>"; };
 		521173B51D9A504800DDA29E /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
+		5221F3541DA35B9100719B90 /* Auth.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Auth.json; sourceTree = "<group>"; };
 		521173B81D9A79AB00DDA29E /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
-		521BC0A21DA3527000A83893 /* MembersCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MembersCell.swift; sourceTree = "<group>"; };
-		521BC0A31DA3527000A83893 /* MembersCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MembersCell.xib; sourceTree = "<group>"; };
-		521BC0A61DA3971200A83893 /* ListDetailUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListDetailUITests.swift; sourceTree = "<group>"; };
+		5222F5A61DA34A0F00990E8E /* ListsMembers.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ListsMembers.json; sourceTree = "<group>"; };
 		521BC0A81DA3B05300A83893 /* ListEdit.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = ListEdit.storyboard; sourceTree = "<group>"; };
 		521BC0AA1DA3B0D600A83893 /* ListEditViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListEditViewController.swift; sourceTree = "<group>"; };
-		5221F3541DA35B9100719B90 /* Auth.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Auth.json; sourceTree = "<group>"; };
-		5222F5A61DA34A0F00990E8E /* ListsMembers.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ListsMembers.json; sourceTree = "<group>"; };
 		5222F5A71DA34A0F00990E8E /* ListsShow.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ListsShow.json; sourceTree = "<group>"; };
 		5222F5A81DA34A0F00990E8E /* MicropostsShow.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MicropostsShow.json; sourceTree = "<group>"; };
 		5222F5A91DA34A0F00990E8E /* MicropostsShow_withPicture.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MicropostsShow_withPicture.json; sourceTree = "<group>"; };
 		5222F5AA1DA34A0F00990E8E /* MyLists.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MyLists.json; sourceTree = "<group>"; };
+		521BC0A21DA3527000A83893 /* MembersCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MembersCell.swift; sourceTree = "<group>"; };
+		521BC0A31DA3527000A83893 /* MembersCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MembersCell.xib; sourceTree = "<group>"; };
+		521BC0A61DA3971200A83893 /* ListDetailUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListDetailUITests.swift; sourceTree = "<group>"; };
 		5222F5AB1DA34A0F00990E8E /* UsersCreate.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UsersCreate.json; sourceTree = "<group>"; };
 		522C8AA61D9CBC2C00E17D4C /* List.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = List.swift; sourceTree = "<group>"; };
 		522C8AAE1D9D1D3F00E17D4C /* TestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
@@ -103,9 +104,9 @@
 		525B70781D98F985004D72BD /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
 		525B70791D98F985004D72BD /* AlamofireImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AlamofireImage.framework; path = Carthage/Build/iOS/AlamofireImage.framework; sourceTree = "<group>"; };
 		525B707A1D98F985004D72BD /* SwiftyJSON.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyJSON.framework; path = Carthage/Build/iOS/SwiftyJSON.framework; sourceTree = "<group>"; };
-		52685A261D990E4400FEC0A7 /* APIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		526B149D1DA4A21F00BDAAFA /* MembersDeleteCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MembersDeleteCell.swift; sourceTree = "<group>"; };
 		526B149E1DA4A21F00BDAAFA /* MembersDeleteCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MembersDeleteCell.xib; sourceTree = "<group>"; };
+		52685A261D990E4400FEC0A7 /* APIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		52A15F281DA1FABA009D4525 /* ListUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListUITests.swift; sourceTree = "<group>"; };
 		52A15F371DA24923009D4525 /* ListTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListTests.swift; sourceTree = "<group>"; };
 		52A44A7A1D9E304500DE76FD /* ListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
@@ -117,7 +118,6 @@
 		52B1C6E31D98EFD2002AB83B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		52B1C6E81D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		52B1C6ED1D98EFD2002AB83B /* TurmericTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TurmericTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		52B1C6F31D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		725B13171DA35C4600A12006 /* Me.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Me.json; sourceTree = "<group>"; };
 		72C0D6DF1D9BB50600D47723 /* Feed.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Feed.storyboard; sourceTree = "<group>"; };
 		72C0D6E11D9BB54A00D47723 /* Following.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Following.storyboard; sourceTree = "<group>"; };
@@ -126,16 +126,18 @@
 		72C0D6E71D9BBC9000D47723 /* LinedButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinedButton.swift; sourceTree = "<group>"; };
 		72C0D6EB1D9CBBE200D47723 /* ProfileUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileUITests.swift; sourceTree = "<group>"; };
 		72C0D6ED1D9D106000D47723 /* ProfileViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
+		52B1C6F31D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		52B1C6F81D98EFD2002AB83B /* TurmericUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TurmericUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		52B1C6FE1D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		52D6E7C01D9CE22900A0A564 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserTests.swift; sourceTree = "<group>"; };
 		52F1EF4C1DA39BD1009B4327 /* MyFeed.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MyFeed.json; sourceTree = "<group>"; };
+		52D6E7C01D9CE22900A0A564 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserTests.swift; sourceTree = "<group>"; };
 		7231C3D81D9A0BA90086D60F /* Mention.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Mention.storyboard; sourceTree = "<group>"; };
 		724DB9121D9926FB00008C25 /* Home.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Home.storyboard; sourceTree = "<group>"; };
 		724DB9141D99271B00008C25 /* Post.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Post.storyboard; sourceTree = "<group>"; };
 		724DB9161D99274A00008C25 /* Profile.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Profile.storyboard; sourceTree = "<group>"; };
 		724DB9181D99275300008C25 /* Lists.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Lists.storyboard; sourceTree = "<group>"; };
 		725B13121DA2450C00A12006 /* Stub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stub.swift; sourceTree = "<group>"; };
+		725B13191DA39AFC00A12006 /* PostKeyboardToolbar.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PostKeyboardToolbar.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -185,8 +187,8 @@
 				5221F3541DA35B9100719B90 /* Auth.json */,
 				5222F5A61DA34A0F00990E8E /* ListsMembers.json */,
 				5222F5A71DA34A0F00990E8E /* ListsShow.json */,
-				5222F5A91DA34A0F00990E8E /* MicropostsShow_withPicture.json */,
 				5222F5A81DA34A0F00990E8E /* MicropostsShow.json */,
+				5222F5A91DA34A0F00990E8E /* MicropostsShow_withPicture.json */,
 				52F1EF4C1DA39BD1009B4327 /* MyFeed.json */,
 				725B13171DA35C4600A12006 /* Me.json */,
 				5222F5AA1DA34A0F00990E8E /* MyLists.json */,
@@ -253,6 +255,7 @@
 				521BC0A31DA3527000A83893 /* MembersCell.xib */,
 				526B149D1DA4A21F00BDAAFA /* MembersDeleteCell.swift */,
 				526B149E1DA4A21F00BDAAFA /* MembersDeleteCell.xib */,
+				725B13191DA39AFC00A12006 /* PostKeyboardToolbar.xib */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -458,22 +461,23 @@
 				5222F5B11DA34A0F00990E8E /* UsersCreate.json in Resources */,
 				5222F5AF1DA34A0F00990E8E /* MicropostsShow_withPicture.json in Resources */,
 				521BC0A91DA3B05300A83893 /* ListEdit.storyboard in Resources */,
-				724DB9171D99274A00008C25 /* Profile.storyboard in Resources */,
+				725B131A1DA39AFC00A12006 /* PostKeyboardToolbar.xib in Resources */,
 				5221F3551DA35B9100719B90 /* Auth.json in Resources */,
 				72C0D6E01D9BB50600D47723 /* Feed.storyboard in Resources */,
+				724DB9171D99274A00008C25 /* Profile.storyboard in Resources */,
 				5242ABFC1D98F1CB0095D4F4 /* Main.storyboard in Resources */,
 				52B1C6E41D98EFD2002AB83B /* Assets.xcassets in Resources */,
-				5222F5AC1DA34A0F00990E8E /* ListsMembers.json in Resources */,
 				725B13181DA35C4600A12006 /* Me.json in Resources */,
-				7231C3D91D9A0BA90086D60F /* Mention.storyboard in Resources */,
+				5222F5AC1DA34A0F00990E8E /* ListsMembers.json in Resources */,
 				52F1EF4D1DA39BD1009B4327 /* MyFeed.json in Resources */,
+				7231C3D91D9A0BA90086D60F /* Mention.storyboard in Resources */,
 				52A44A871D9E465800DE76FD /* ListDetail.storyboard in Resources */,
-				5222F5AD1DA34A0F00990E8E /* ListsShow.json in Resources */,
 				72C0D6E61D9BB70900D47723 /* ProfileEdit.storyboard in Resources */,
-				5242ABFB1D98F1CB0095D4F4 /* LaunchScreen.storyboard in Resources */,
+				5222F5AD1DA34A0F00990E8E /* ListsShow.json in Resources */,
 				72C0D6E41D9BB56100D47723 /* Followers.storyboard in Resources */,
-				5222F5B01DA34A0F00990E8E /* MyLists.json in Resources */,
+				5242ABFB1D98F1CB0095D4F4 /* LaunchScreen.storyboard in Resources */,
 				521BC0A51DA3527000A83893 /* MembersCell.xib in Resources */,
+				5222F5B01DA34A0F00990E8E /* MyLists.json in Resources */,
 				724DB9151D99271B00008C25 /* Post.storyboard in Resources */,
 				724DB9131D9926FB00008C25 /* Home.storyboard in Resources */,
 				724DB9191D99275300008C25 /* Lists.storyboard in Resources */,

--- a/Turmeric.xcodeproj/project.pbxproj
+++ b/Turmeric.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		725B131A1DA39AFC00A12006 /* PostKeyboardToolbar.xib in Resources */ = {isa = PBXBuildFile; fileRef = 725B13191DA39AFC00A12006 /* PostKeyboardToolbar.xib */; };
 		72B14FF71DA39D79005E7523 /* PostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B14FF61DA39D79005E7523 /* PostViewController.swift */; };
 		72B14FF91DA3B11D005E7523 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B14FF81DA3B11D005E7523 /* TabBarController.swift */; };
+		72B14FFB1DA49D4E005E7523 /* DummyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B14FFA1DA49D4E005E7523 /* DummyViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -84,16 +85,16 @@
 /* Begin PBXFileReference section */
 		5221F3541DA35B9100719B90 /* Auth.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Auth.json; sourceTree = "<group>"; };
 		520654661D9E086500FD0BBE /* MicropostTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MicropostTests.swift; sourceTree = "<group>"; };
-		521173B51D9A504800DDA29E /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		521BC0A81DA3B05300A83893 /* ListEdit.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = ListEdit.storyboard; sourceTree = "<group>"; };
 		521BC0AA1DA3B0D600A83893 /* ListEditViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListEditViewController.swift; sourceTree = "<group>"; };
+		521173B51D9A504800DDA29E /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		521173B81D9A79AB00DDA29E /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
 		5222F5A61DA34A0F00990E8E /* ListsMembers.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ListsMembers.json; sourceTree = "<group>"; };
 		5222F5A71DA34A0F00990E8E /* ListsShow.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ListsShow.json; sourceTree = "<group>"; };
-		5222F5A81DA34A0F00990E8E /* MicropostsShow.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MicropostsShow.json; sourceTree = "<group>"; };
 		521BC0A21DA3527000A83893 /* MembersCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MembersCell.swift; sourceTree = "<group>"; };
 		521BC0A31DA3527000A83893 /* MembersCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MembersCell.xib; sourceTree = "<group>"; };
 		521BC0A61DA3971200A83893 /* ListDetailUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListDetailUITests.swift; sourceTree = "<group>"; };
+		5222F5A81DA34A0F00990E8E /* MicropostsShow.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MicropostsShow.json; sourceTree = "<group>"; };
 		5222F5A91DA34A0F00990E8E /* MicropostsShow_withPicture.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MicropostsShow_withPicture.json; sourceTree = "<group>"; };
 		5222F5AA1DA34A0F00990E8E /* MyLists.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MyLists.json; sourceTree = "<group>"; };
 		5222F5AB1DA34A0F00990E8E /* UsersCreate.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UsersCreate.json; sourceTree = "<group>"; };
@@ -103,9 +104,9 @@
 		5242ABF71D98F1BE0095D4F4 /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		5242ABF91D98F1CB0095D4F4 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		5242ABFA1D98F1CB0095D4F4 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
-		525B70781D98F985004D72BD /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
 		526B149D1DA4A21F00BDAAFA /* MembersDeleteCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MembersDeleteCell.swift; sourceTree = "<group>"; };
 		526B149E1DA4A21F00BDAAFA /* MembersDeleteCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MembersDeleteCell.xib; sourceTree = "<group>"; };
+		525B70781D98F985004D72BD /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
 		525B70791D98F985004D72BD /* AlamofireImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AlamofireImage.framework; path = Carthage/Build/iOS/AlamofireImage.framework; sourceTree = "<group>"; };
 		525B707A1D98F985004D72BD /* SwiftyJSON.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyJSON.framework; path = Carthage/Build/iOS/SwiftyJSON.framework; sourceTree = "<group>"; };
 		52685A261D990E4400FEC0A7 /* APIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
@@ -117,7 +118,6 @@
 		52A635D21D9CD9FE00646119 /* Micropost.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Micropost.swift; sourceTree = "<group>"; };
 		52B1C6D91D98EFD2002AB83B /* Turmeric.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Turmeric.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		52B1C6DC1D98EFD2002AB83B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		52B1C6E31D98EFD2002AB83B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		725B13171DA35C4600A12006 /* Me.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Me.json; sourceTree = "<group>"; };
 		72C0D6DF1D9BB50600D47723 /* Feed.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Feed.storyboard; sourceTree = "<group>"; };
 		72C0D6E11D9BB54A00D47723 /* Following.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Following.storyboard; sourceTree = "<group>"; };
@@ -126,10 +126,11 @@
 		72C0D6E71D9BBC9000D47723 /* LinedButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinedButton.swift; sourceTree = "<group>"; };
 		72C0D6EB1D9CBBE200D47723 /* ProfileUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileUITests.swift; sourceTree = "<group>"; };
 		72C0D6ED1D9D106000D47723 /* ProfileViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
+		52B1C6E31D98EFD2002AB83B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		52B1C6E81D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		52B1C6ED1D98EFD2002AB83B /* TurmericTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TurmericTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		52B1C6F31D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		52F1EF4C1DA39BD1009B4327 /* MyFeed.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MyFeed.json; sourceTree = "<group>"; };
+		52B1C6F31D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		52B1C6F81D98EFD2002AB83B /* TurmericUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TurmericUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		52B1C6FE1D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		52D6E7C01D9CE22900A0A564 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserTests.swift; sourceTree = "<group>"; };
@@ -142,6 +143,7 @@
 		725B13191DA39AFC00A12006 /* PostKeyboardToolbar.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PostKeyboardToolbar.xib; sourceTree = "<group>"; };
 		72B14FF61DA39D79005E7523 /* PostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostViewController.swift; sourceTree = "<group>"; };
 		72B14FF81DA3B11D005E7523 /* TabBarController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
+		72B14FFA1DA49D4E005E7523 /* DummyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DummyViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -223,6 +225,7 @@
 				521BC0AA1DA3B0D600A83893 /* ListEditViewController.swift */,
 				72B14FF61DA39D79005E7523 /* PostViewController.swift */,
 				72B14FF81DA3B11D005E7523 /* TabBarController.swift */,
+				72B14FFA1DA49D4E005E7523 /* DummyViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -562,6 +565,7 @@
 				72B14FF71DA39D79005E7523 /* PostViewController.swift in Sources */,
 				521BC0AB1DA3B0D600A83893 /* ListEditViewController.swift in Sources */,
 				725B13131DA2450C00A12006 /* Stub.swift in Sources */,
+				72B14FFB1DA49D4E005E7523 /* DummyViewController.swift in Sources */,
 				52B1C6DD1D98EFD2002AB83B /* AppDelegate.swift in Sources */,
 				522C8AA71D9CBC2C00E17D4C /* List.swift in Sources */,
 				52685A271D990E4400FEC0A7 /* APIClient.swift in Sources */,

--- a/Turmeric.xcodeproj/project.pbxproj
+++ b/Turmeric.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		725B13131DA2450C00A12006 /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725B13121DA2450C00A12006 /* Stub.swift */; };
 		725B131A1DA39AFC00A12006 /* PostKeyboardToolbar.xib in Resources */ = {isa = PBXBuildFile; fileRef = 725B13191DA39AFC00A12006 /* PostKeyboardToolbar.xib */; };
 		72B14FF71DA39D79005E7523 /* PostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B14FF61DA39D79005E7523 /* PostViewController.swift */; };
+		72B14FF91DA3B11D005E7523 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B14FF81DA3B11D005E7523 /* TabBarController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,19 +82,19 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		520654661D9E086500FD0BBE /* MicropostTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MicropostTests.swift; sourceTree = "<group>"; };
 		5221F3541DA35B9100719B90 /* Auth.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Auth.json; sourceTree = "<group>"; };
+		520654661D9E086500FD0BBE /* MicropostTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MicropostTests.swift; sourceTree = "<group>"; };
 		521173B51D9A504800DDA29E /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
-		521173B81D9A79AB00DDA29E /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
 		521BC0A81DA3B05300A83893 /* ListEdit.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = ListEdit.storyboard; sourceTree = "<group>"; };
 		521BC0AA1DA3B0D600A83893 /* ListEditViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListEditViewController.swift; sourceTree = "<group>"; };
+		521173B81D9A79AB00DDA29E /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
 		5222F5A61DA34A0F00990E8E /* ListsMembers.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ListsMembers.json; sourceTree = "<group>"; };
 		5222F5A71DA34A0F00990E8E /* ListsShow.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ListsShow.json; sourceTree = "<group>"; };
 		5222F5A81DA34A0F00990E8E /* MicropostsShow.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MicropostsShow.json; sourceTree = "<group>"; };
-		5222F5A91DA34A0F00990E8E /* MicropostsShow_withPicture.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MicropostsShow_withPicture.json; sourceTree = "<group>"; };
 		521BC0A21DA3527000A83893 /* MembersCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MembersCell.swift; sourceTree = "<group>"; };
 		521BC0A31DA3527000A83893 /* MembersCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MembersCell.xib; sourceTree = "<group>"; };
 		521BC0A61DA3971200A83893 /* ListDetailUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListDetailUITests.swift; sourceTree = "<group>"; };
+		5222F5A91DA34A0F00990E8E /* MicropostsShow_withPicture.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MicropostsShow_withPicture.json; sourceTree = "<group>"; };
 		5222F5AA1DA34A0F00990E8E /* MyLists.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MyLists.json; sourceTree = "<group>"; };
 		5222F5AB1DA34A0F00990E8E /* UsersCreate.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UsersCreate.json; sourceTree = "<group>"; };
 		522C8AA61D9CBC2C00E17D4C /* List.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = List.swift; sourceTree = "<group>"; };
@@ -103,9 +104,9 @@
 		5242ABF91D98F1CB0095D4F4 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		5242ABFA1D98F1CB0095D4F4 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		525B70781D98F985004D72BD /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
-		525B70791D98F985004D72BD /* AlamofireImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AlamofireImage.framework; path = Carthage/Build/iOS/AlamofireImage.framework; sourceTree = "<group>"; };
 		526B149D1DA4A21F00BDAAFA /* MembersDeleteCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MembersDeleteCell.swift; sourceTree = "<group>"; };
 		526B149E1DA4A21F00BDAAFA /* MembersDeleteCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MembersDeleteCell.xib; sourceTree = "<group>"; };
+		525B70791D98F985004D72BD /* AlamofireImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AlamofireImage.framework; path = Carthage/Build/iOS/AlamofireImage.framework; sourceTree = "<group>"; };
 		525B707A1D98F985004D72BD /* SwiftyJSON.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyJSON.framework; path = Carthage/Build/iOS/SwiftyJSON.framework; sourceTree = "<group>"; };
 		52685A261D990E4400FEC0A7 /* APIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		52A15F281DA1FABA009D4525 /* ListUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListUITests.swift; sourceTree = "<group>"; };
@@ -117,7 +118,6 @@
 		52B1C6D91D98EFD2002AB83B /* Turmeric.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Turmeric.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		52B1C6DC1D98EFD2002AB83B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		52B1C6E31D98EFD2002AB83B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		52B1C6E81D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		725B13171DA35C4600A12006 /* Me.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Me.json; sourceTree = "<group>"; };
 		72C0D6DF1D9BB50600D47723 /* Feed.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Feed.storyboard; sourceTree = "<group>"; };
 		72C0D6E11D9BB54A00D47723 /* Following.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Following.storyboard; sourceTree = "<group>"; };
@@ -126,10 +126,11 @@
 		72C0D6E71D9BBC9000D47723 /* LinedButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinedButton.swift; sourceTree = "<group>"; };
 		72C0D6EB1D9CBBE200D47723 /* ProfileUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileUITests.swift; sourceTree = "<group>"; };
 		72C0D6ED1D9D106000D47723 /* ProfileViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
+		52B1C6E81D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		52B1C6ED1D98EFD2002AB83B /* TurmericTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TurmericTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		52B1C6F31D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		52B1C6F81D98EFD2002AB83B /* TurmericUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TurmericUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		52F1EF4C1DA39BD1009B4327 /* MyFeed.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MyFeed.json; sourceTree = "<group>"; };
+		52B1C6F81D98EFD2002AB83B /* TurmericUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TurmericUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		52B1C6FE1D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		52D6E7C01D9CE22900A0A564 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserTests.swift; sourceTree = "<group>"; };
 		7231C3D81D9A0BA90086D60F /* Mention.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Mention.storyboard; sourceTree = "<group>"; };
@@ -140,6 +141,7 @@
 		725B13121DA2450C00A12006 /* Stub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stub.swift; sourceTree = "<group>"; };
 		725B13191DA39AFC00A12006 /* PostKeyboardToolbar.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PostKeyboardToolbar.xib; sourceTree = "<group>"; };
 		72B14FF61DA39D79005E7523 /* PostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostViewController.swift; sourceTree = "<group>"; };
+		72B14FF81DA3B11D005E7523 /* TabBarController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -220,6 +222,7 @@
 				72C0D6ED1D9D106000D47723 /* ProfileViewController.swift */,
 				521BC0AA1DA3B0D600A83893 /* ListEditViewController.swift */,
 				72B14FF61DA39D79005E7523 /* PostViewController.swift */,
+				72B14FF81DA3B11D005E7523 /* TabBarController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -551,13 +554,14 @@
 				52A44A891D9E512600DE76FD /* ListDetailViewController.swift in Sources */,
 				72C0D6E81D9BBC9000D47723 /* LinedButton.swift in Sources */,
 				52A635D31D9CD9FE00646119 /* Micropost.swift in Sources */,
-				5232599F1D9A0D8100476111 /* User.swift in Sources */,
+				72B14FF91DA3B11D005E7523 /* TabBarController.swift in Sources */,
 				526B149F1DA4A21F00BDAAFA /* MembersDeleteCell.swift in Sources */,
+				5232599F1D9A0D8100476111 /* User.swift in Sources */,
 				5242ABF81D98F1BE0095D4F4 /* ViewController.swift in Sources */,
-				72B14FF71DA39D79005E7523 /* PostViewController.swift in Sources */,
 				72C0D6EE1D9D106000D47723 /* ProfileViewController.swift in Sources */,
-				725B13131DA2450C00A12006 /* Stub.swift in Sources */,
+				72B14FF71DA39D79005E7523 /* PostViewController.swift in Sources */,
 				521BC0AB1DA3B0D600A83893 /* ListEditViewController.swift in Sources */,
+				725B13131DA2450C00A12006 /* Stub.swift in Sources */,
 				52B1C6DD1D98EFD2002AB83B /* AppDelegate.swift in Sources */,
 				522C8AA71D9CBC2C00E17D4C /* List.swift in Sources */,
 				52685A271D990E4400FEC0A7 /* APIClient.swift in Sources */,

--- a/Turmeric/Classes/Controllers/DummyViewController.swift
+++ b/Turmeric/Classes/Controllers/DummyViewController.swift
@@ -1,0 +1,35 @@
+//
+//  DummyViewController.swift
+//  Turmeric
+//
+//  Created by usr0600437 on 2016/10/05.
+//  Copyright © 2016年 GMO Pepabo. All rights reserved.
+//
+
+import UIKit
+
+class DummyViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destinationViewController.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Turmeric/Classes/Controllers/PostViewController.swift
+++ b/Turmeric/Classes/Controllers/PostViewController.swift
@@ -9,10 +9,16 @@
 import UIKit
 
 class PostViewController: UIViewController {
+    @IBOutlet weak var postTextView: UITextView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        // XIBファイルからカスタムビューを取得、インスタンス化
+        let toolbar = UINib(nibName: "PostKeyboardToolbar", bundle: nil).instantiate(withOwner: self, options: nil)[0] as! UIToolbar
+        
+        // テキスト入力の際、キーボードの上に追加で表示されるビュー
+        self.postTextView.inputAccessoryView = toolbar
     }
 
     override func didReceiveMemoryWarning() {

--- a/Turmeric/Classes/Controllers/PostViewController.swift
+++ b/Turmeric/Classes/Controllers/PostViewController.swift
@@ -1,0 +1,21 @@
+//
+//  PostViewController.swift
+//  Turmeric
+//
+//  Created by usr0600437 on 2016/10/04.
+//  Copyright © 2016年 GMO Pepabo. All rights reserved.
+//
+
+import UIKit
+
+class PostViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+    }
+}

--- a/Turmeric/Classes/Controllers/PostViewController.swift
+++ b/Turmeric/Classes/Controllers/PostViewController.swift
@@ -10,7 +10,13 @@ import UIKit
 
 class PostViewController: UIViewController {
     @IBOutlet weak var postTextView: UITextView!
-
+    @IBOutlet weak var iconImageView: UIImageView!
+    
+    @IBAction func closeButtonDidTapped(_ sender: AnyObject) {
+        postTextView.resignFirstResponder() //キーボードを非アクティブ化
+        self.dismiss(animated: true, completion: nil)   //モーダルを閉じる
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/Turmeric/Classes/Controllers/PostViewController.swift
+++ b/Turmeric/Classes/Controllers/PostViewController.swift
@@ -14,6 +14,9 @@ class PostViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        // ページ開いたら自動フォーカス
+        postTextView.becomeFirstResponder()
+        
         // XIBファイルからカスタムビューを取得、インスタンス化
         let toolbar = UINib(nibName: "PostKeyboardToolbar", bundle: nil).instantiate(withOwner: self, options: nil)[0] as! UIToolbar
         

--- a/Turmeric/Classes/Controllers/TabBarController.swift
+++ b/Turmeric/Classes/Controllers/TabBarController.swift
@@ -21,16 +21,18 @@ class TabBarController: UITabBarController, UITabBarControllerDelegate {
     
     // viewControllerに切り替えるタブがタップされた際に呼ばれ、遷移するかどうかを判定
     func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
-        // 投稿画面以外は全部問題なく切り替え
-        if !(viewController is PostViewController) {
+        // 投稿画面の(ダミー画面)以外は全部問題なく切り替え
+        if !(viewController is DummyViewController) {
            return true
         }
         
-        // 投稿画面は切り替えずにモーダルを表示
+        // 投稿画面をモーダル表示
         if let currentVC = self.selectedViewController{
-            currentVC.present(viewController, animated: true, completion: nil)
+            let vc = UIStoryboard(name: "Post", bundle: nil).instantiateInitialViewController()
+            currentVC.present(vc!, animated: true, completion: nil)
         }
         
+        // ダミー画面は表示しない
         return false
     }
 }

--- a/Turmeric/Classes/Controllers/TabBarController.swift
+++ b/Turmeric/Classes/Controllers/TabBarController.swift
@@ -1,0 +1,36 @@
+//
+//  TabBarController.swift
+//  Turmeric
+//
+//  Created by usr0600437 on 2016/10/04.
+//  Copyright © 2016年 GMO Pepabo. All rights reserved.
+//
+
+import UIKit
+
+class TabBarController: UITabBarController, UITabBarControllerDelegate {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.delegate = self
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+    }
+    
+    // viewControllerに切り替えるタブがタップされた際に呼ばれ、遷移するかどうかを判定
+    func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
+        // 投稿画面以外は全部問題なく切り替え
+        if !(viewController is PostViewController) {
+           return true
+        }
+        
+        // 投稿画面は切り替えずにモーダルを表示
+        if let currentVC = self.selectedViewController{
+            currentVC.present(viewController, animated: true, completion: nil)
+        }
+        
+        return false
+    }
+}

--- a/Turmeric/Classes/Views/PostKeyboardToolbar.xib
+++ b/Turmeric/Classes/Views/PostKeyboardToolbar.xib
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="TKM-fe-P1B">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+            <items>
+                <barButtonItem title="画像" id="TNz-4U-2Ng"/>
+                <barButtonItem style="plain" systemItem="flexibleSpace" id="ZGp-Yc-JI1"/>
+                <barButtonItem style="plain" id="eVf-h3-gej">
+                    <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="8Xb-ol-VJN">
+                        <rect key="frame" x="328" y="7" width="31" height="30"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <state key="normal" title="投稿"/>
+                    </button>
+                </barButtonItem>
+            </items>
+            <point key="canvasLocation" x="-545" y="358"/>
+        </toolbar>
+    </objects>
+</document>

--- a/Turmeric/Storyboards/Main.storyboard
+++ b/Turmeric/Storyboards/Main.storyboard
@@ -57,7 +57,7 @@
             </objects>
             <point key="canvasLocation" x="-1033" y="61"/>
         </scene>
-        <!--Item-->
+        <!--投稿-->
         <scene sceneID="EDV-Zp-pZ2">
             <objects>
                 <viewController id="5x2-61-YA4" customClass="DummyViewController" customModule="Turmeric" customModuleProvider="target" sceneMemberID="viewController">
@@ -70,7 +70,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Item" id="bWd-od-Mbs"/>
+                    <tabBarItem key="tabBarItem" title="投稿" id="bWd-od-Mbs"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="D7R-Wf-CMv" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Turmeric/Storyboards/Main.storyboard
+++ b/Turmeric/Storyboards/Main.storyboard
@@ -9,7 +9,7 @@
         <!--Tab Bar Controller-->
         <scene sceneID="jTJ-PE-qgF">
             <objects>
-                <tabBarController id="Zvd-9n-caL" sceneMemberID="viewController">
+                <tabBarController id="Zvd-9n-caL" customClass="TabBarController" customModule="Turmeric" customModuleProvider="target" sceneMemberID="viewController">
                     <tabBar key="tabBar" contentMode="scaleToFill" id="zjA-pX-vN8">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="49"/>
                         <autoresizingMask key="autoresizingMask"/>

--- a/Turmeric/Storyboards/Main.storyboard
+++ b/Turmeric/Storyboards/Main.storyboard
@@ -18,7 +18,7 @@
                     <connections>
                         <segue destination="oYf-uQ-Nn2" kind="relationship" relationship="viewControllers" id="GIL-D6-yta"/>
                         <segue destination="Veb-Lr-qfr" kind="relationship" relationship="viewControllers" id="5mx-F6-29T"/>
-                        <segue destination="mz0-jX-A0M" kind="relationship" relationship="viewControllers" id="9jL-Yl-OPB"/>
+                        <segue destination="5x2-61-YA4" kind="relationship" relationship="viewControllers" id="NLo-zS-biO"/>
                         <segue destination="qa6-Xi-O3F" kind="relationship" relationship="viewControllers" id="eO5-QK-kyV"/>
                         <segue destination="rft-SR-PqB" kind="relationship" relationship="viewControllers" id="H9v-K2-lNM"/>
                     </connections>
@@ -47,16 +47,6 @@
             </objects>
             <point key="canvasLocation" x="-1033" y="-184"/>
         </scene>
-        <!--Post-->
-        <scene sceneID="H8h-xP-LtC">
-            <objects>
-                <viewControllerPlaceholder storyboardName="Post" id="mz0-jX-A0M" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Item" id="FSQ-7h-Uz4"/>
-                </viewControllerPlaceholder>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="yq9-mE-AeW" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-1032" y="-61"/>
-        </scene>
         <!--Profile-->
         <scene sceneID="dtH-fs-qiK">
             <objects>
@@ -66,6 +56,25 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="KU9-KU-Xtx" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-1033" y="61"/>
+        </scene>
+        <!--Item-->
+        <scene sceneID="EDV-Zp-pZ2">
+            <objects>
+                <viewController id="5x2-61-YA4" customClass="DummyViewController" customModule="Turmeric" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="OIv-fq-00l"/>
+                        <viewControllerLayoutGuide type="bottom" id="uw4-9d-rME"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="jKg-RW-Yyr">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="Item" id="bWd-od-Mbs"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="D7R-Wf-CMv" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-479" y="-54"/>
         </scene>
         <!--Lists-->
         <scene sceneID="TIw-pn-ld8">

--- a/Turmeric/Storyboards/Post.storyboard
+++ b/Turmeric/Storyboards/Post.storyboard
@@ -21,10 +21,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RVG-ZU-Evk">
+                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RVG-ZU-Evk">
+                                <frame key="frameInset" minX="309" minY="20" width="46" height="30"/>
                                 <state key="normal" title="閉じる"/>
                                 <connections>
-                                    <action selector="goBack" destination="zUd-aa-ud9" eventType="touchUpInside" id="fGC-dh-tv4"/>
+                                    <action selector="closeButtonDidTapped:" destination="SHx-TC-7lW" eventType="touchUpInside" id="h0H-4P-nj9"/>
                                 </connections>
                             </button>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="dgT-r5-Fet">
@@ -54,6 +55,7 @@
                     </view>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
+                        <outlet property="iconImageView" destination="dgT-r5-Fet" id="KvE-N0-Mnl"/>
                         <outlet property="postTextView" destination="Wz7-fi-KcY" id="Ooi-cu-7YX"/>
                     </connections>
                 </viewController>

--- a/Turmeric/Storyboards/Post.storyboard
+++ b/Turmeric/Storyboards/Post.storyboard
@@ -3,6 +3,9 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -18,18 +21,31 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Post" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tTc-Ac-YBE">
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RVG-ZU-Evk">
+                                <state key="normal" title="閉じる"/>
+                            </button>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="dgT-r5-Fet">
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="dgT-r5-Fet" secondAttribute="height" multiplier="1:1" id="euw-bV-kyy"/>
+                                </constraints>
+                            </imageView>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wz7-fi-KcY">
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <fontDescription key="fontDescription" name=".HiraKakuInterface-W3" family=".Hiragino Kaku Gothic Interface" pointSize="18"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="tTc-Ac-YBE" firstAttribute="centerY" secondItem="wEg-bl-yIT" secondAttribute="centerY" id="FGo-v7-U4C"/>
-                            <constraint firstItem="tTc-Ac-YBE" firstAttribute="centerY" secondItem="wEg-bl-yIT" secondAttribute="centerY" id="eys-2G-WI6"/>
-                            <constraint firstItem="tTc-Ac-YBE" firstAttribute="centerX" secondItem="wEg-bl-yIT" secondAttribute="centerX" id="meF-JO-h2F"/>
-                            <constraint firstItem="tTc-Ac-YBE" firstAttribute="centerX" secondItem="wEg-bl-yIT" secondAttribute="centerX" id="vf1-7h-9Gm"/>
+                            <constraint firstItem="Y7z-zG-NFD" firstAttribute="top" secondItem="Wz7-fi-KcY" secondAttribute="bottom" id="6ZW-Iq-25k"/>
+                            <constraint firstItem="dgT-r5-Fet" firstAttribute="top" secondItem="Mhe-9q-LRo" secondAttribute="bottom" id="A64-Un-JkE"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="RVG-ZU-Evk" secondAttribute="trailing" id="I7r-g1-MAP"/>
+                            <constraint firstItem="Wz7-fi-KcY" firstAttribute="top" secondItem="dgT-r5-Fet" secondAttribute="bottom" id="Ozd-At-5E1"/>
+                            <constraint firstItem="Wz7-fi-KcY" firstAttribute="trailing" secondItem="wEg-bl-yIT" secondAttribute="trailingMargin" id="e3c-fJ-Ut7"/>
+                            <constraint firstItem="dgT-r5-Fet" firstAttribute="leading" secondItem="wEg-bl-yIT" secondAttribute="leadingMargin" id="es9-AE-Cb7"/>
+                            <constraint firstItem="Wz7-fi-KcY" firstAttribute="leading" secondItem="wEg-bl-yIT" secondAttribute="leadingMargin" id="kzh-rh-yJe"/>
+                            <constraint firstItem="dgT-r5-Fet" firstAttribute="width" secondItem="wEg-bl-yIT" secondAttribute="width" multiplier="0.2" id="uHi-pF-ePj"/>
+                            <constraint firstItem="RVG-ZU-Evk" firstAttribute="top" secondItem="Mhe-9q-LRo" secondAttribute="bottom" id="zYc-Kn-51o"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="ポスト" id="A7e-2q-HFY"/>

--- a/Turmeric/Storyboards/Post.storyboard
+++ b/Turmeric/Storyboards/Post.storyboard
@@ -12,7 +12,7 @@
         <!--ポスト-->
         <scene sceneID="2kR-ce-HRK">
             <objects>
-                <viewController id="SHx-TC-7lW" sceneMemberID="viewController">
+                <viewController id="SHx-TC-7lW" customClass="PostViewController" customModule="Turmeric" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="Mhe-9q-LRo"/>
                         <viewControllerLayoutGuide type="bottom" id="Y7z-zG-NFD"/>
@@ -23,6 +23,9 @@
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RVG-ZU-Evk">
                                 <state key="normal" title="閉じる"/>
+                                <connections>
+                                    <action selector="goBack" destination="zUd-aa-ud9" eventType="touchUpInside" id="fGC-dh-tv4"/>
+                                </connections>
                             </button>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="dgT-r5-Fet">
                                 <constraints>
@@ -31,6 +34,7 @@
                             </imageView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wz7-fi-KcY">
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <accessibility key="accessibilityConfiguration" identifier="PostTextView"/>
                                 <fontDescription key="fontDescription" name=".HiraKakuInterface-W3" family=".Hiragino Kaku Gothic Interface" pointSize="18"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
@@ -50,6 +54,9 @@
                     </view>
                     <tabBarItem key="tabBarItem" title="ポスト" id="A7e-2q-HFY"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="postTextView" destination="Wz7-fi-KcY" id="Ooi-cu-7YX"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="zUd-aa-ud9" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Turmeric/Storyboards/Post.storyboard
+++ b/Turmeric/Storyboards/Post.storyboard
@@ -9,10 +9,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--ポスト-->
+        <!--Post View Controller-->
         <scene sceneID="2kR-ce-HRK">
             <objects>
-                <viewController id="SHx-TC-7lW" customClass="PostViewController" customModule="Turmeric" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Post" id="SHx-TC-7lW" customClass="PostViewController" customModule="Turmeric" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="Mhe-9q-LRo"/>
                         <viewControllerLayoutGuide type="bottom" id="Y7z-zG-NFD"/>
@@ -52,7 +52,6 @@
                             <constraint firstItem="RVG-ZU-Evk" firstAttribute="top" secondItem="Mhe-9q-LRo" secondAttribute="bottom" id="zYc-Kn-51o"/>
                         </constraints>
                     </view>
-                    <tabBarItem key="tabBarItem" title="ポスト" id="A7e-2q-HFY"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="postTextView" destination="Wz7-fi-KcY" id="Ooi-cu-7YX"/>

--- a/Turmeric/Storyboards/Post.storyboard
+++ b/Turmeric/Storyboards/Post.storyboard
@@ -18,11 +18,10 @@
                         <viewControllerLayoutGuide type="bottom" id="Y7z-zG-NFD"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="wEg-bl-yIT">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RVG-ZU-Evk">
-                                <frame key="frameInset" minX="309" minY="20" width="46" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RVG-ZU-Evk">
                                 <state key="normal" title="閉じる"/>
                                 <connections>
                                     <action selector="closeButtonDidTapped:" destination="SHx-TC-7lW" eventType="touchUpInside" id="h0H-4P-nj9"/>


### PR DESCRIPTION
投稿ページのレイアウト関係の部分を作ります。
### やったこと
- [x] TabBarの挙動を変更
  - [x] Main.storyboardでのTabBarでPostのページに切り替えず、Dummyページを配置
  - [x] TabBarViewControllerを追加
  - [x] TabBarのDummyが押された時、ページを"切り替えず"にPostページをモーダル表示(TabBarVC内実装)
- [x] Postページの表示
  - [x] レイアウト
  - [x] TextViewの入力時にキーボード上に「投稿」「画像」ボタンの配置されているビューを表示
  - [x] 閉じるボタンタップでモーダルを閉じる
### まだやってないこと
- APIとの連携全般
  - 投稿を押しても投稿されない
  - 投稿ページのユーザ画像は表示されない
- カメラロールの起動
