### PR TITLE
フィードをTableViewに表示する

### DIFF
--- a/Turmeric.xcodeproj/project.pbxproj
+++ b/Turmeric.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		52B1C6E41D98EFD2002AB83B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 52B1C6E31D98EFD2002AB83B /* Assets.xcassets */; };
 		52D1FEF11DA4EAC20025FCD4 /* XLPagerTabStrip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D1FEF01DA4EAC20025FCD4 /* XLPagerTabStrip.framework */; };
 		52D6E7C11D9CE22900A0A564 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52D6E7C01D9CE22900A0A564 /* UserTests.swift */; };
+		52EC66D71DA764B500A2D53D /* FeedUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EC66D61DA764B500A2D53D /* FeedUITests.swift */; };
 		52F1EF4D1DA39BD1009B4327 /* MyFeed.json in Resources */ = {isa = PBXBuildFile; fileRef = 52F1EF4C1DA39BD1009B4327 /* MyFeed.json */; };
 		7231C3D91D9A0BA90086D60F /* Mention.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7231C3D81D9A0BA90086D60F /* Mention.storyboard */; };
 		724DB9131D9926FB00008C25 /* Home.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9121D9926FB00008C25 /* Home.storyboard */; };
@@ -155,6 +156,7 @@
 		52B1C6FE1D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		52D1FEF01DA4EAC20025FCD4 /* XLPagerTabStrip.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XLPagerTabStrip.framework; path = Carthage/Build/iOS/XLPagerTabStrip.framework; sourceTree = "<group>"; };
 		52D6E7C01D9CE22900A0A564 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserTests.swift; sourceTree = "<group>"; };
+		52EC66D61DA764B500A2D53D /* FeedUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedUITests.swift; sourceTree = "<group>"; };
 		52F1EF4C1DA39BD1009B4327 /* MyFeed.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MyFeed.json; sourceTree = "<group>"; };
 		7231C3D81D9A0BA90086D60F /* Mention.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Mention.storyboard; sourceTree = "<group>"; };
 		724DB9121D9926FB00008C25 /* Home.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Home.storyboard; sourceTree = "<group>"; };
@@ -403,6 +405,7 @@
 			isa = PBXGroup;
 			children = (
 				52B1C6FE1D98EFD2002AB83B /* Info.plist */,
+				52EC66D61DA764B500A2D53D /* FeedUITests.swift */,
 				528F83581DA5F70F00630ACF /* HomeUITests.swift */,
 				52A15F281DA1FABA009D4525 /* ListUITests.swift */,
 				72B150001DA5EEE4005E7523 /* PostUITests.swift */,
@@ -663,6 +666,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5208BBD81DA76AD60098DBC6 /* ListAddMemberUITests.swift in Sources */,
+				52EC66D71DA764B500A2D53D /* FeedUITests.swift in Sources */,
 				528F83591DA5F70F00630ACF /* HomeUITests.swift in Sources */,
 				521BC0A71DA3971200A83893 /* ListDetailUITests.swift in Sources */,
 				72C0D6EC1D9CBBE200D47723 /* ProfileUITests.swift in Sources */,

--- a/Turmeric/Classes/Controllers/FeedViewController.swift
+++ b/Turmeric/Classes/Controllers/FeedViewController.swift
@@ -3,6 +3,7 @@ import XLPagerTabStrip
 
 class FeedViewController: UITableViewController, IndicatorInfoProvider {
     var itemInfo = IndicatorInfo(title: "Feed")
+    var microposts = [Micropost]()
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
@@ -11,16 +12,14 @@ class FeedViewController: UITableViewController, IndicatorInfoProvider {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Uncomment the following line to preserve selection between presentations
-        // self.clearsSelectionOnViewWillAppear = false
-
-        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
-        // self.navigationItem.rightBarButtonItem = self.editButtonItem()
+        User.getMyFeed { feed in
+            self.microposts = feed!
+            self.tableView.reloadData()
+        }
     }
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
     }
 
     // IndicatorInfoProviderでが必要なメソッド
@@ -29,71 +28,14 @@ class FeedViewController: UITableViewController, IndicatorInfoProvider {
         return itemInfo
     }
 
-    // MARK: - Table view data source
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        // #warning Incomplete implementation, return the number of sections
-        return 0
-    }
-
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // #warning Incomplete implementation, return the number of rows
-        return 0
+        return self.microposts.count
     }
 
-    /*
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
-
-        // Configure the cell...
+        let cell = tableView.dequeueReusableCell(withIdentifier: "micropostCell", for: indexPath)
+        cell.textLabel?.text = self.microposts[indexPath.row].content
 
         return cell
     }
-    */
-
-    /*
-    // Override to support conditional editing of the table view.
-    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the specified item to be editable.
-        return true
-    }
-    */
-
-    /*
-    // Override to support editing the table view.
-    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
-        if editingStyle == .delete {
-            // Delete the row from the data source
-            tableView.deleteRows(at: [indexPath], with: .fade)
-        } else if editingStyle == .insert {
-            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
-        }
-    }
-    */
-
-    /*
-    // Override to support rearranging the table view.
-    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
-
-    }
-    */
-
-    /*
-    // Override to support conditional rearranging of the table view.
-    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the item to be re-orderable.
-        return true
-    }
-    */
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destinationViewController.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
 }

--- a/Turmeric/Storyboards/Feed.storyboard
+++ b/Turmeric/Storyboards/Feed.storyboard
@@ -15,12 +15,21 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="sSD-Or-qwV">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="micropostCell" textLabel="TRi-ZB-ffr" style="IBUITableViewCellStyleDefault" id="sSD-Or-qwV">
                                 <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="sSD-Or-qwV" id="43w-bh-JjL">
                                     <frame key="frameInset" width="375" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="TRi-ZB-ffr">
+                                            <frame key="frameInset" minX="15" width="345" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
                                 </tableViewCellContentView>
                             </tableViewCell>
                         </prototypes>

--- a/TurmericUITests/FeedUITests.swift
+++ b/TurmericUITests/FeedUITests.swift
@@ -11,15 +11,16 @@ class FeedUITests: XCTestCase {
         super.tearDown()
     }
 
+    // ホームフィード(通常のタイムライン)
     func testHomeFeed() {
         let app = XCUIApplication()
-        // ホームフィード(通常のタイムライン)
         app.tabBars.buttons["ホーム"].tap()
         let micropostCells = app.tables.cells
         XCTAssertEqual(10, micropostCells.count)
         XCTAssert(micropostCells.staticTexts["Writing a short test"].exists)
     }
 
+    // リストフィード(リストに追加されたユーザーの投稿)
     func testListFeed() {
         let app = XCUIApplication()
         app.tabBars.buttons["ホーム"].tap()
@@ -27,7 +28,17 @@ class FeedUITests: XCTestCase {
         // Friendsリストのフィードに移動
         swipeTab.staticTexts["Friends"].tap()
         let micropostCells = app.tables.cells
-        // TODO: リストのフィードが取得できるようになったら、リストフィードにしかないテキストがあるかを確認する
+        // TODO: リストのフィードが取得できるようになったら個数やテキストを変更する
+        XCTAssertEqual(10, micropostCells.count)
+        XCTAssert(micropostCells.staticTexts["Writing a short test"].exists)
+    }
+
+    // プロフィールフィード(プロフィールページの自分の投稿)
+    func testProfileFeed() {
+        let app = XCUIApplication()
+        app.tabBars.buttons["プロフィール"].tap()
+        let micropostCells = app.tables.cells
+        // TODO: プロフィールフィードが取得できるようになったら個数やテキストを変更する
         XCTAssertEqual(10, micropostCells.count)
         XCTAssert(micropostCells.staticTexts["Writing a short test"].exists)
     }

--- a/TurmericUITests/FeedUITests.swift
+++ b/TurmericUITests/FeedUITests.swift
@@ -13,5 +13,22 @@ class FeedUITests: XCTestCase {
 
     func testHomeFeed() {
         let app = XCUIApplication()
+        // ホームフィード(通常のタイムライン)
+        app.tabBars.buttons["ホーム"].tap()
+        let micropostCells = app.tables.cells
+        XCTAssertEqual(10, micropostCells.count)
+        XCTAssert(micropostCells.staticTexts["Writing a short test"].exists)
+    }
+
+    func testListFeed() {
+        let app = XCUIApplication()
+        app.tabBars.buttons["ホーム"].tap()
+        let swipeTab = app.navigationBars["Turmeric.HomeView"].collectionViews
+        // Friendsリストのフィードに移動
+        swipeTab.staticTexts["Friends"].tap()
+        let micropostCells = app.tables.cells
+        // TODO: リストのフィードが取得できるようになったら、リストフィードにしかないテキストがあるかを確認する
+        XCTAssertEqual(10, micropostCells.count)
+        XCTAssert(micropostCells.staticTexts["Writing a short test"].exists)
     }
 }

--- a/TurmericUITests/FeedUITests.swift
+++ b/TurmericUITests/FeedUITests.swift
@@ -1,0 +1,17 @@
+import XCTest
+
+class FeedUITests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        XCUIApplication().launch()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testHomeFeed() {
+        let app = XCUIApplication()
+    }
+}


### PR DESCRIPTION
- 単純にフィード（MyFeed：通常のタイムライン）を表示するだけです
- 次にマイクロポストのデザインを行います（いまはセルのカスタムもせずに、テキストのみ表示しています）
- フィード・リストのフィード・プロフィールの自分の投稿一覧もすべてMyFeedになっていますが、それぞれで取得先を変えるのも別PRにします（実装悩み中）

いまのところこうなります。

![2016-10-07 15 31 22](https://cloud.githubusercontent.com/assets/1928324/19180727/20544cb8-8ca3-11e6-9142-7aac49fd06c0.png)
