### PR TITLE
モデルのプロパティでURLなものはURL型にする

### DIFF
--- a/Turmeric/Classes/Controllers/ListAddMemberViewController.swift
+++ b/Turmeric/Classes/Controllers/ListAddMemberViewController.swift
@@ -59,8 +59,7 @@ class ListAddMemberViewController: UIViewController, UITableViewDelegate, UITabl
 
         let followingUser = self.followings[indexPath.row]
 
-        let url = followingUser.iconURL
-        cell.iconImage.af_setImage(withURL: url)
+        cell.iconImage.af_setImage(withURL: followingUser.iconURL)
         cell.name.text = followingUser.name
 
         let addButton = cell.addButton!

--- a/Turmeric/Classes/Controllers/ListAddMemberViewController.swift
+++ b/Turmeric/Classes/Controllers/ListAddMemberViewController.swift
@@ -9,20 +9,20 @@
 import UIKit
 
 class ListAddMemberViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
-    
+
     var followings: [User] = []
     var members: [User] = []
     var selectedListId: Int = 0
-    
+
     @IBOutlet weak var tableView: UITableView!
-    
+
     @IBAction func cancelButtonTapped(_ sender: AnyObject) {
         self.dismiss(animated: true, completion: nil)
     }
     override func viewDidLoad() {
         super.viewDidLoad()
         self.tableView.register(UINib(nibName: "MembersAddCell", bundle: nil), forCellReuseIdentifier: "membersAddCell")
-        
+
         User.getMyUser(){ me in
             User.getFollowing(id: me.id){ following in
                 // すでにリストに追加されているユーザは取り除く
@@ -32,51 +32,51 @@ class ListAddMemberViewController: UIViewController, UITableViewDelegate, UITabl
                 self.tableView.reloadData()
             }
         }
-        
+
         // テーブルの一番上に線を引く
         let frame = CGRect(x: 0, y: 0, width: self.tableView.frame.width, height: 0.5)
         self.tableView.tableHeaderView = UIView(frame: frame)
         self.tableView.tableHeaderView!.backgroundColor = UIColor.black
     }
-    
+
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         tableView.tableFooterView = UIView()
         // Dispose of any resources that can be recreated.
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         tableView.tableFooterView = UIView()
     }
-    
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return self.followings.count
     }
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = self.tableView.dequeueReusableCell(withIdentifier: "membersAddCell", for: indexPath) as! MembersAddCell
-        
+
         let followingUser = self.followings[indexPath.row]
-        
-        let url = URL(string: followingUser.iconURL)!
+
+        let url = followingUser.iconURL
         cell.iconImage.af_setImage(withURL: url)
         cell.name.text = followingUser.name
-        
+
         let addButton = cell.addButton!
-        
+
         //追加ボタンタップ時のコールバック設定
         addButton.addTarget(self, action: #selector(ListAddMemberViewController.addButtonTap), for: .touchDown)
-        
+
         return cell
     }
-    
+
     func addButtonTap(sender: UIButton, event: UIEvent) {
         if let touch = event.allTouches?.first {
             // タッチされたボタンの位置からindexPathを検出
             let point = touch.location(in: self.tableView)
             let indexPath = self.tableView.indexPathForRow(at: point)!
-            
+
             let tappedUser = self.followings[indexPath.row]
             List.addMember(id: self.selectedListId, parameters: ["user_id" : tappedUser.id]) { response in
                 self.dismiss(animated: true, completion: nil)

--- a/Turmeric/Classes/Controllers/ListDetailViewController.swift
+++ b/Turmeric/Classes/Controllers/ListDetailViewController.swift
@@ -57,8 +57,7 @@ class ListDetailViewController: UIViewController, UITableViewDelegate, UITableVi
         let cell = self.tableView.dequeueReusableCell(withIdentifier: "membersCell", for: indexPath) as! MembersCell
 
         let member = self.members[indexPath.row]
-        let url = member.iconURL
-        cell.iconImage.af_setImage(withURL: url)
+        cell.iconImage.af_setImage(withURL: member.iconURL)
         cell.name.text = member.name
 
         return cell

--- a/Turmeric/Classes/Controllers/ListDetailViewController.swift
+++ b/Turmeric/Classes/Controllers/ListDetailViewController.swift
@@ -15,31 +15,31 @@ class ListDetailViewController: UIViewController, UITableViewDelegate, UITableVi
     var selectedListId: Int?
     var list: List? = nil
     var members: [User] = []
-    
+
     @IBOutlet weak var listNameLabel: UILabel!
     @IBOutlet weak var tableView: UITableView!
-    
+
     @IBAction func unwindToListDetailScreen(sender: UIStoryboardSegue) {
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         self.tableView.register(UINib(nibName: "MembersCell", bundle: nil), forCellReuseIdentifier: "membersCell")
-        
+
         self.requestData()
     }
-    
+
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.requestData()
         tableView.tableFooterView = UIView()
     }
-    
+
     override func prepare(for segue: UIStoryboardSegue, sender: Any!) {
         switch segue.identifier! {
         case "goEdit":
@@ -48,28 +48,28 @@ class ListDetailViewController: UIViewController, UITableViewDelegate, UITableVi
         default : break
         }
     }
-    
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return self.members.count
     }
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = self.tableView.dequeueReusableCell(withIdentifier: "membersCell", for: indexPath) as! MembersCell
-        
+
         let member = self.members[indexPath.row]
-        let url = URL(string: member.iconURL)!
+        let url = member.iconURL
         cell.iconImage.af_setImage(withURL: url)
         cell.name.text = member.name
-        
+
         return cell
     }
-    
+
     private func requestData() {
         List.getList(id: self.selectedListId!) { response in
             self.list = response
             self.listNameLabel.text = response.name
         }
-        
+
         List.getMembers(id: self.selectedListId!) { response in
             self.members = response
             self.tableView.reloadData()

--- a/Turmeric/Classes/Controllers/ListEditViewController.swift
+++ b/Turmeric/Classes/Controllers/ListEditViewController.swift
@@ -84,8 +84,7 @@ class ListEditViewController: UIViewController, UITableViewDelegate, UITableView
         let cell = self.tableView.dequeueReusableCell(withIdentifier: "membersDeleteCell", for: indexPath) as! MembersDeleteCell
 
         let member = self.members[indexPath.row]
-        let url = member.iconURL
-        cell.iconImage.af_setImage(withURL: url)
+        cell.iconImage.af_setImage(withURL: member.iconURL)
         cell.name.text = member.name
         let deleteButton = cell.deleteButton!
 

--- a/Turmeric/Classes/Controllers/ListEditViewController.swift
+++ b/Turmeric/Classes/Controllers/ListEditViewController.swift
@@ -8,18 +8,18 @@
 import UIKit
 
 class ListEditViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
-    
+
     var selectedListId: Int?
     var list: List? = nil
     var members: [User] = []
     var deleteMembers: [User] = []
-    
+
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var listNameField: UITextField!
-    
+
     @IBAction func updateButtonTapped(_ sender: AnyObject) {
         let group = DispatchGroup.init()
-        
+
         // リスト名が変更前後で変わっていない場合、リスト名が空文字列の場合はAPIにリクエストを発行しない
         if (self.list!.name != self.listNameField.text && self.listNameField.text != "") {
             group.enter()
@@ -30,21 +30,21 @@ class ListEditViewController: UIViewController, UITableViewDelegate, UITableView
             }
         }
 
-        
+
         self.deleteMembers.forEach{
             group.enter()
             List.deleteMember(listId: self.list!.id, memberId: $0.id) {
                 group.leave()
             }
         }
-        
+
         //全てのAPIのレスポンスを受け取った後に画面遷移する
         group.notify(queue: DispatchQueue.main, execute: {
             self.performSegue(withIdentifier: "unwind", sender: nil)
         })
-        
+
     }
-    
+
     override func prepare(for segue: UIStoryboardSegue, sender: Any!) {
         switch segue.identifier! {
         case "goAddMember":
@@ -54,75 +54,75 @@ class ListEditViewController: UIViewController, UITableViewDelegate, UITableView
         default : break
         }
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         self.tableView.register(UINib(nibName: "MembersDeleteCell", bundle: nil), forCellReuseIdentifier: "membersDeleteCell")
-        
+
         let frame = CGRect(x: 0, y: 0, width: self.tableView.frame.width, height: 0.5)
         self.tableView.tableHeaderView = UIView(frame: frame)
         self.tableView.tableHeaderView!.backgroundColor = UIColor.black
-        
+
         requestData()
     }
-    
+
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         tableView.tableFooterView = UIView()
         requestData()
     }
-    
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return self.members.count
     }
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = self.tableView.dequeueReusableCell(withIdentifier: "membersDeleteCell", for: indexPath) as! MembersDeleteCell
-        
+
         let member = self.members[indexPath.row]
-        let url = URL(string: member.iconURL)!
+        let url = member.iconURL
         cell.iconImage.af_setImage(withURL: url)
         cell.name.text = member.name
         let deleteButton = cell.deleteButton!
-        
+
         //削除ボタンタップ時のコールバック設定
         deleteButton.addTarget(self, action: #selector(ListEditViewController.deleteButtonTap), for: .touchDown)
         return cell
     }
-    
+
     func deleteButtonTap(sender: UIButton, event: UIEvent) {
         if let touch = event.allTouches?.first {
             // タッチされたボタンの位置からindexPathを検出
             let point = touch.location(in: self.tableView)
             let indexPath = self.tableView.indexPathForRow(at: point)
             let cell = self.tableView.cellForRow(at: indexPath!) as! MembersDeleteCell
-            
+
             // 削除ボタンの該当ユーザをdeleteMemberとして保存する
             self.deleteMembers.append(members[(indexPath?.row)!])
-            
+
             // 該当セルの背景をグレイにし、削除ボタンを非表示にする
             cell.selectionStyle = .none
             cell.backgroundColor = UIColor.lightGray
             cell.deleteButton.isHidden = true
         }
     }
-    
+
     func tableView(_ table: UITableView,didSelectRowAt indexPath: IndexPath) {
         let cell = self.tableView.cellForRow(at: indexPath)!
         // セル内で削除ボタン以外がタッチされても背景を変えない
         cell.selectionStyle = .none
     }
-    
+
     private func requestData() {
         List.getList(id: self.selectedListId!) { response in
             self.list = response
             self.listNameField.text = response.name
         }
-        
+
         List.getMembers(id: self.selectedListId!) { response in
             self.members = response
             self.tableView.reloadData()

--- a/Turmeric/Classes/Controllers/PostViewController.swift
+++ b/Turmeric/Classes/Controllers/PostViewController.swift
@@ -12,39 +12,39 @@ import Alamofire
 class PostViewController: UIViewController {
     @IBOutlet weak var postTextView: UITextView!
     @IBOutlet weak var iconImageView: UIImageView!
-    
+
     @IBAction func closeButtonDidTapped(_ sender: AnyObject) {
         postTextView.resignFirstResponder() //キーボードを非アクティブ化
         self.dismiss(animated: true, completion: nil)   //モーダルを閉じる
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         // アイコン表示
         User.getMyUser(){ user in
             do {
-                let data = try Data(contentsOf: URL(string: user.iconURL)! )
+                let data = try Data(contentsOf: user.iconURL )
                 self.iconImageView.image = UIImage(data: data)
             } catch {
                 //画像がダウンロードできなかった
             }
         }
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         // ページ開いたら自動フォーカス
         postTextView.becomeFirstResponder()
-        
+
         // XIBファイルからカスタムビューを取得、インスタンス化
         let toolbar = UINib(nibName: "PostKeyboardToolbar", bundle: nil).instantiate(withOwner: self, options: nil)[0] as! UIToolbar
-        
+
         // テキスト入力の際、キーボードの上に追加で表示されるビュー
         self.postTextView.inputAccessoryView = toolbar
-        
-        
+
+
         let postButton: UIBarButtonItem = toolbar.items![2]
-        
+
         postButton.target = self;
         postButton.action = #selector(PostViewController.postButtonDidTap)
     }
@@ -52,9 +52,9 @@ class PostViewController: UIViewController {
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
     }
-    
+
     func postButtonDidTap(){
-        
+
         if let postText = postTextView.text {
             let parameters: [String : Any] = ["micropost": [
                 "content": postText
@@ -62,7 +62,7 @@ class PostViewController: UIViewController {
             ]
 
             Micropost.postMicropost(parameters: parameters, handler: {micropost in })
-        
+
             postTextView.resignFirstResponder() //キーボードを非アクティブ化
             self.dismiss(animated: true, completion: nil)   //モーダルを閉じる
         }

--- a/Turmeric/Classes/Controllers/ProfileViewController.swift
+++ b/Turmeric/Classes/Controllers/ProfileViewController.swift
@@ -15,23 +15,23 @@ class ProfileViewController: UIViewController {
     @IBOutlet weak var followersButton: UIButton!
     @IBOutlet weak var followingButton: UIButton!
     @IBOutlet weak var profileImage: UIImageView!
-    
+
     //var followingButton: UIButton
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+
         User.getMyUser(){ user in
             self.usernameLabel.text = user.name
-            
+
             if let micropostCount = user.micropostsCount, let followersCount = user.followersCount, let followingCount = user.followingCount {
                 self.micropostsLabel.text = micropostCount.description
-                
+
                 self.followersButton.setTitle(followersCount.description, for: UIControlState.normal)
                 self.followingButton.setTitle(followingCount.description, for: UIControlState.normal)
             }
-            
+
             do {
-                let data = try Data(contentsOf: URL(string: user.iconURL)! )
+                let data = try Data(contentsOf: user.iconURL )
                 self.profileImage.image = UIImage(data: data)
             } catch {
                 //画像がダウンロードできなかった
@@ -42,12 +42,12 @@ class ProfileViewController: UIViewController {
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
     }
-    
+
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         guard let segueID = segue.identifier else {
             return
         }
-        
+
         switch(segueID){
         case "following":
             let vc = segue.destination as! UsersViewController
@@ -61,7 +61,7 @@ class ProfileViewController: UIViewController {
             break
         case "followers":
             let vc = segue.destination as! UsersViewController
-            
+
             // 次のvcに自分のフォロワーたちを表示するように依頼
             User.getMyUser(){ me in
                 User.getFollowers(id: me.id){ followers in

--- a/Turmeric/Classes/Models/Micropost.swift
+++ b/Turmeric/Classes/Models/Micropost.swift
@@ -6,9 +6,9 @@ class Micropost {
     let id: Int
     let userId: Int
     let content: String
-    let picture: NSURL?
+    let picture: URL?
 
-    init(id: Int, userId: Int, content: String, picture: NSURL?) {
+    init(id: Int, userId: Int, content: String, picture: URL?) {
         self.id = id
         self.userId = userId
         self.content = content
@@ -20,12 +20,12 @@ class Micropost {
         self.userId = json["user_id"].int!
         self.content = json["content"].string!
         if let picture = json["picture"].string {
-            self.picture = NSURL(string: picture)
+            self.picture = URL(string: picture)
         } else {
             self.picture = nil
         }
     }
-    
+
     static func postMicropost(parameters: Parameters, handler: @escaping ((Micropost) -> Void)) {
         APIClient.request(endpoint: Endpoint.MicropostsPost, parameters: parameters) { json in
             handler(Micropost(json: json["micropost"]))

--- a/Turmeric/Classes/Models/User.swift
+++ b/Turmeric/Classes/Models/User.swift
@@ -7,17 +7,17 @@ class User {
     let id: Int
     let name: String
     let email: String?
-    let iconURL: String
+    let iconURL: URL
     let followingCount: Int?
     let followersCount: Int?
     let micropostsCount: Int?
 
-    init(id: Int, name: String, iconURL: String, email: String? = nil) {
+    init(id: Int, name: String, iconURL: URL, email: String? = nil) {
         self.id = id
         self.name = name
         self.email = email
         self.iconURL = iconURL
-        
+
         self.followersCount  = nil
         self.followingCount  = nil
         self.micropostsCount = nil
@@ -31,7 +31,7 @@ class User {
         self.followingCount  = json["following_count"].int
         self.followersCount  = json["followers_count"].int
         self.micropostsCount = json["microposts_count"].int
-        self.iconURL = json["icon_url"].string!
+        self.iconURL = URL(string: json["icon_url"].string!)!
     }
 
     static func createUser(parameters: Parameters, handler: @escaping ((User) -> Void)) {
@@ -39,7 +39,7 @@ class User {
             handler(User(json: json["user"]))
         }
     }
-    
+
     static func getMyUser(handler: @escaping ((User) -> Void)) {
         APIClient.request(endpoint: Endpoint.UsersMe, parameters: [:]) { json in
             handler(User(json: json["user"]))
@@ -70,14 +70,14 @@ class User {
             handler(lists)
         }
     }
-    
+
     static func getFollowing(id: Int, handler: @escaping (([User]?) -> Void) ) {
         APIClient.request(endpoint: Endpoint.UsersFollowing(id)) { json in
             let users: [User]? = (json["following"]["users"].array?.map { User(json: $0) })
             handler(users)
         }
     }
-    
+
     static func getFollowers(id: Int, handler: @escaping (([User]?) -> Void) ) {
         APIClient.request(endpoint: Endpoint.UsersFollowers(id)) { json in
             let users: [User]? = (json["followers"]["users"].array?.map { User(json: $0) })

--- a/Turmeric/Classes/Views/MembersFollow.swift
+++ b/Turmeric/Classes/Views/MembersFollow.swift
@@ -12,7 +12,7 @@ class MembersFollow: UITableViewCell {
     @IBOutlet weak var iconImage: UIImageView!
     @IBOutlet weak var button: UIButton!
     @IBOutlet weak var name: UILabel!
-    
+
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
@@ -23,13 +23,13 @@ class MembersFollow: UITableViewCell {
 
         // Configure the view for the selected state
     }
-    
+
     func displayUser(user: User, following:Bool = false){
         name.text = user.name
-        
+
         let title: String = following ? "アンフォロー" : "フォロー"
         button.setTitle(title, for: UIControlState.normal)
-        
-        iconImage.af_setImage(withURL: URL(string: user.iconURL)!)
+
+        iconImage.af_setImage(withURL: user.iconURL)
     }
 }

--- a/TurmericTests/Models/UserTests.swift
+++ b/TurmericTests/Models/UserTests.swift
@@ -36,7 +36,7 @@ class UserTests: XCTestCase {
             }
         }
     }
-    
+
     func testUserMe() {
         waitUntil { done in
             User.getMyUser(){ response in
@@ -44,12 +44,12 @@ class UserTests: XCTestCase {
                 XCTAssertEqual(100, response.followingCount)
                 XCTAssertEqual(200, response.followersCount)
                 XCTAssertEqual(1000, response.micropostsCount)
-                XCTAssertEqual("https://secure.gravatar.com/avatar/b58996c504c5638798eb6b511e6f49af?s=80", response.iconURL)
+                XCTAssertEqual("https://secure.gravatar.com/avatar/b58996c504c5638798eb6b511e6f49af?s=80", response.iconURL.absoluteString)
                 done()
             }
         }
     }
-    
+
     func testUserLogin() {
         waitUntil { done in
             User.authenticate(parameters: ["user": ["email": "test@example.com", "password": "F0oB@rbaz"]]) { response in
@@ -75,7 +75,7 @@ class UserTests: XCTestCase {
 
     func testGetMyLists() {
         login()
-        
+
         waitUntil { done in
             User.getMyLists { response in
                 response!.forEach {
@@ -86,10 +86,10 @@ class UserTests: XCTestCase {
             }
         }
     }
-    
+
     func testFollowing() {
         login()
-        
+
         waitUntil { done in
             User.getFollowing(id: 1) { response in
                 response!.forEach {
@@ -100,10 +100,10 @@ class UserTests: XCTestCase {
             }
         }
     }
-    
+
     func testFollowers() {
         login()
-        
+
         waitUntil { done in
             User.getFollowers(id: 1) { response in
                 response!.forEach {


### PR DESCRIPTION
使うときにいちいち`URL(string: 〜)`とやるのは効率が悪いので、はじめからURL型にします
- UserのiconURLプロパティをURL型にする
- MicropostのpictureプロパティはURL型になってますが、NSURL型になってるのでURL型に統一

`〜URL`をつけるかつけないかで統一したいですが、これはレスポンスJSONの時点でそうなっているため、統一するときはAPIと同時に変更したいためこのPRでは扱いません。

エディタでやってたら空白差分がやたら出てしまったので、↓で空白無視してください。
https://github.com/pepabo-mobile-app-training/turmeric/pull/61/files?w=
