### PR TITLE
フォロー・アンフォロー機能の実装

### DIFF
--- a/Turmeric.xcodeproj/project.pbxproj
+++ b/Turmeric.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		72B1501A1DA6576A005E7523 /* UsersFollowers.json in Resources */ = {isa = PBXBuildFile; fileRef = 72B150191DA6576A005E7523 /* UsersFollowers.json */; };
 		72B1501C1DA6577C005E7523 /* UsersFollowing.json in Resources */ = {isa = PBXBuildFile; fileRef = 72B1501B1DA6577C005E7523 /* UsersFollowing.json */; };
 		72B1501E1DA768B1005E7523 /* Relationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B1501D1DA768B1005E7523 /* Relationship.swift */; };
+		72B150201DA7807E005E7523 /* RelationshipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B1501F1DA7807E005E7523 /* RelationshipTests.swift */; };
 		72C0D6E01D9BB50600D47723 /* Feed.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 72C0D6DF1D9BB50600D47723 /* Feed.storyboard */; };
 		72C0D6E21D9BB54A00D47723 /* Following.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 72C0D6E11D9BB54A00D47723 /* Following.storyboard */; };
 		72C0D6E41D9BB56100D47723 /* Followers.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 72C0D6E31D9BB56100D47723 /* Followers.storyboard */; };
@@ -175,6 +176,7 @@
 		72B150191DA6576A005E7523 /* UsersFollowers.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UsersFollowers.json; sourceTree = "<group>"; };
 		72B1501B1DA6577C005E7523 /* UsersFollowing.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UsersFollowing.json; sourceTree = "<group>"; };
 		72B1501D1DA768B1005E7523 /* Relationship.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Relationship.swift; sourceTree = "<group>"; };
+		72B1501F1DA7807E005E7523 /* RelationshipTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelationshipTests.swift; sourceTree = "<group>"; };
 		72C0D6DF1D9BB50600D47723 /* Feed.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Feed.storyboard; sourceTree = "<group>"; };
 		72C0D6E11D9BB54A00D47723 /* Following.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Following.storyboard; sourceTree = "<group>"; };
 		72C0D6E31D9BB56100D47723 /* Followers.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Followers.storyboard; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 				52D6E7C01D9CE22900A0A564 /* UserTests.swift */,
 				520654661D9E086500FD0BBE /* MicropostTests.swift */,
 				52A15F371DA24923009D4525 /* ListTests.swift */,
+				72B1501F1DA7807E005E7523 /* RelationshipTests.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -653,6 +656,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				520654671D9E086500FD0BBE /* MicropostTests.swift in Sources */,
+				72B150201DA7807E005E7523 /* RelationshipTests.swift in Sources */,
 				52A15F381DA24923009D4525 /* ListTests.swift in Sources */,
 				52D6E7C11D9CE22900A0A564 /* UserTests.swift in Sources */,
 				522C8AAF1D9D1D3F00E17D4C /* TestHelpers.swift in Sources */,

--- a/Turmeric.xcodeproj/project.pbxproj
+++ b/Turmeric.xcodeproj/project.pbxproj
@@ -58,12 +58,6 @@
 		7231C3D91D9A0BA90086D60F /* Mention.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7231C3D81D9A0BA90086D60F /* Mention.storyboard */; };
 		724DB9131D9926FB00008C25 /* Home.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9121D9926FB00008C25 /* Home.storyboard */; };
 		724DB9151D99271B00008C25 /* Post.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9141D99271B00008C25 /* Post.storyboard */; };
-		72B1500D1DA5FBD9005E7523 /* Users.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 72B1500C1DA5FBD9005E7523 /* Users.storyboard */; };
-		72B150111DA5FE10005E7523 /* UsersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B150101DA5FE10005E7523 /* UsersViewController.swift */; };
-		72B150161DA621D4005E7523 /* MembersFollow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B150141DA621D4005E7523 /* MembersFollow.swift */; };
-		72B150171DA621D4005E7523 /* MembersFollow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 72B150151DA621D4005E7523 /* MembersFollow.xib */; };
-		72B1501A1DA6576A005E7523 /* UsersFollowers.json in Resources */ = {isa = PBXBuildFile; fileRef = 72B150191DA6576A005E7523 /* UsersFollowers.json */; };
-		72B1501C1DA6577C005E7523 /* UsersFollowing.json in Resources */ = {isa = PBXBuildFile; fileRef = 72B1501B1DA6577C005E7523 /* UsersFollowing.json */; };
 		724DB9171D99274A00008C25 /* Profile.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9161D99274A00008C25 /* Profile.storyboard */; };
 		724DB9191D99275300008C25 /* Lists.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9181D99275300008C25 /* Lists.storyboard */; };
 		725B13131DA2450C00A12006 /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725B13121DA2450C00A12006 /* Stub.swift */; };
@@ -74,6 +68,13 @@
 		72B14FFB1DA49D4E005E7523 /* DummyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B14FFA1DA49D4E005E7523 /* DummyViewController.swift */; };
 		72B14FFD1DA4CCEA005E7523 /* MicropostsPost.json in Resources */ = {isa = PBXBuildFile; fileRef = 72B14FFC1DA4CCEA005E7523 /* MicropostsPost.json */; };
 		72B150011DA5EEE4005E7523 /* PostUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B150001DA5EEE4005E7523 /* PostUITests.swift */; };
+		72B1500D1DA5FBD9005E7523 /* Users.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 72B1500C1DA5FBD9005E7523 /* Users.storyboard */; };
+		72B150111DA5FE10005E7523 /* UsersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B150101DA5FE10005E7523 /* UsersViewController.swift */; };
+		72B150161DA621D4005E7523 /* MembersFollow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B150141DA621D4005E7523 /* MembersFollow.swift */; };
+		72B150171DA621D4005E7523 /* MembersFollow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 72B150151DA621D4005E7523 /* MembersFollow.xib */; };
+		72B1501A1DA6576A005E7523 /* UsersFollowers.json in Resources */ = {isa = PBXBuildFile; fileRef = 72B150191DA6576A005E7523 /* UsersFollowers.json */; };
+		72B1501C1DA6577C005E7523 /* UsersFollowing.json in Resources */ = {isa = PBXBuildFile; fileRef = 72B1501B1DA6577C005E7523 /* UsersFollowing.json */; };
+		72B1501E1DA768B1005E7523 /* Relationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B1501D1DA768B1005E7523 /* Relationship.swift */; };
 		72C0D6E01D9BB50600D47723 /* Feed.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 72C0D6DF1D9BB50600D47723 /* Feed.storyboard */; };
 		72C0D6E21D9BB54A00D47723 /* Following.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 72C0D6E11D9BB54A00D47723 /* Following.storyboard */; };
 		72C0D6E41D9BB56100D47723 /* Followers.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 72C0D6E31D9BB56100D47723 /* Followers.storyboard */; };
@@ -147,12 +148,6 @@
 		52B1C6DC1D98EFD2002AB83B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		52B1C6E31D98EFD2002AB83B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		52B1C6E81D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		72B1500C1DA5FBD9005E7523 /* Users.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Users.storyboard; sourceTree = "<group>"; };
-		72B150101DA5FE10005E7523 /* UsersViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UsersViewController.swift; sourceTree = "<group>"; };
-		72B150141DA621D4005E7523 /* MembersFollow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MembersFollow.swift; sourceTree = "<group>"; };
-		72B150151DA621D4005E7523 /* MembersFollow.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MembersFollow.xib; sourceTree = "<group>"; };
-		72B150191DA6576A005E7523 /* UsersFollowers.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UsersFollowers.json; sourceTree = "<group>"; };
-		72B1501B1DA6577C005E7523 /* UsersFollowing.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UsersFollowing.json; sourceTree = "<group>"; };
 		52B1C6ED1D98EFD2002AB83B /* TurmericTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TurmericTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		52B1C6F31D98EFD2002AB83B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		52B1C6F81D98EFD2002AB83B /* TurmericUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TurmericUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -173,6 +168,13 @@
 		72B14FFA1DA49D4E005E7523 /* DummyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DummyViewController.swift; sourceTree = "<group>"; };
 		72B14FFC1DA4CCEA005E7523 /* MicropostsPost.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MicropostsPost.json; sourceTree = "<group>"; };
 		72B150001DA5EEE4005E7523 /* PostUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostUITests.swift; sourceTree = "<group>"; };
+		72B1500C1DA5FBD9005E7523 /* Users.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Users.storyboard; sourceTree = "<group>"; };
+		72B150101DA5FE10005E7523 /* UsersViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UsersViewController.swift; sourceTree = "<group>"; };
+		72B150141DA621D4005E7523 /* MembersFollow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MembersFollow.swift; sourceTree = "<group>"; };
+		72B150151DA621D4005E7523 /* MembersFollow.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MembersFollow.xib; sourceTree = "<group>"; };
+		72B150191DA6576A005E7523 /* UsersFollowers.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UsersFollowers.json; sourceTree = "<group>"; };
+		72B1501B1DA6577C005E7523 /* UsersFollowing.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UsersFollowing.json; sourceTree = "<group>"; };
+		72B1501D1DA768B1005E7523 /* Relationship.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Relationship.swift; sourceTree = "<group>"; };
 		72C0D6DF1D9BB50600D47723 /* Feed.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Feed.storyboard; sourceTree = "<group>"; };
 		72C0D6E11D9BB54A00D47723 /* Following.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Following.storyboard; sourceTree = "<group>"; };
 		72C0D6E31D9BB56100D47723 /* Followers.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Followers.storyboard; sourceTree = "<group>"; };
@@ -290,6 +292,7 @@
 				5232599E1D9A0D8100476111 /* User.swift */,
 				522C8AA61D9CBC2C00E17D4C /* List.swift */,
 				52A635D21D9CD9FE00646119 /* Micropost.swift */,
+				72B1501D1DA768B1005E7523 /* Relationship.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -625,6 +628,7 @@
 				72C0D6E81D9BBC9000D47723 /* LinedButton.swift in Sources */,
 				52A635D31D9CD9FE00646119 /* Micropost.swift in Sources */,
 				52221D261DA4E95E00AA6DD4 /* FeedViewController.swift in Sources */,
+				72B1501E1DA768B1005E7523 /* Relationship.swift in Sources */,
 				72B14FF91DA3B11D005E7523 /* TabBarController.swift in Sources */,
 				72B150111DA5FE10005E7523 /* UsersViewController.swift in Sources */,
 				52221D241DA4E83700AA6DD4 /* HomeViewController.swift in Sources */,

--- a/Turmeric/Classes/Controllers/UsersViewController.swift
+++ b/Turmeric/Classes/Controllers/UsersViewController.swift
@@ -21,7 +21,6 @@ class UsersViewController: UITableViewController {
     }
     private var displayUsersVal: [User] = [] // displayUsersの実データ部
     
-    
     override func viewDidLoad() {
         // MembersFollow.xib のカスタムビューを基準としてターブルビューに配置する
         tableView.register(UINib(nibName: "MembersFollow", bundle: nil), forCellReuseIdentifier: "membersFollow")

--- a/Turmeric/Classes/Controllers/UsersViewController.swift
+++ b/Turmeric/Classes/Controllers/UsersViewController.swift
@@ -22,7 +22,7 @@ class UsersViewController: UITableViewController {
     private var displayUsersVal: [User] = [] // displayUsersの実データ部
     
     override func viewDidLoad() {
-        // MembersFollow.xib のカスタムビューを基準としてターブルビューに配置する
+        // MembersFollow.xib のカスタムビューを基準としてテーブルビューに配置する
         tableView.register(UINib(nibName: "MembersFollow", bundle: nil), forCellReuseIdentifier: "membersFollow")
 
         super.viewDidLoad()

--- a/Turmeric/Classes/Helpers/APIClient.swift
+++ b/Turmeric/Classes/Helpers/APIClient.swift
@@ -116,7 +116,7 @@ enum Endpoint {
         case .ListsUpdate(let listId): return "/api/lists/\(listId)"
         case .ListsDeleteMember(let listId, let memberId): return "/api/lists/\(listId)/members/\(memberId)"
             
-        case .RelationshipCreate:  return "/api/relationship"
+        case .RelationshipCreate:  return "/api/relationships"
         case .RelationshipDestroy: return "/api/relationship"
         }
     }

--- a/Turmeric/Classes/Helpers/APIClient.swift
+++ b/Turmeric/Classes/Helpers/APIClient.swift
@@ -63,6 +63,10 @@ enum Endpoint {
     case ListsUpdate(Int)
     case ListsDeleteMember(Int, Int)
 
+    // Relationship
+    case RelationshipCreate
+    case RelationshipDestroy
+    
     func method() -> HTTPMethod {
         switch self {
         case .Auth: return .post
@@ -84,6 +88,9 @@ enum Endpoint {
         case .ListsMembers: return .get
         case .ListsUpdate: return .patch
         case .ListsDeleteMember: return .delete
+            
+        case .RelationshipCreate:  return .post
+        case .RelationshipDestroy: return .delete
         }
     }
 
@@ -108,6 +115,9 @@ enum Endpoint {
         case .ListsMembers(let listId): return "/api/lists/\(listId)/members"
         case .ListsUpdate(let listId): return "/api/lists/\(listId)"
         case .ListsDeleteMember(let listId, let memberId): return "/api/lists/\(listId)/members/\(memberId)"
+            
+        case .RelationshipCreate:  return "/api/relationship"
+        case .RelationshipDestroy: return "/api/relationship"
         }
     }
 }

--- a/Turmeric/Classes/Helpers/Stub.swift
+++ b/Turmeric/Classes/Helpers/Stub.swift
@@ -119,7 +119,7 @@ func enableHTTPStubs() {
     stub(condition: isHost("currry.xyz") && isPath("/api/relationship") && isMethodDELETE()) { _ in
         return OHHTTPStubsResponse(jsonObject : [], statusCode: 200, headers: nil)
     }
-    stub(condition: isHost("currry.xyz") && isPath("/api/relationship") && isMethodPOST()) { _ in
+    stub(condition: isHost("currry.xyz") && isPath("/api/relationships") && isMethodPOST()) { _ in
         return OHHTTPStubsResponse(jsonObject : [], statusCode: 200, headers: nil)
     }
 }

--- a/Turmeric/Classes/Helpers/Stub.swift
+++ b/Turmeric/Classes/Helpers/Stub.swift
@@ -114,6 +114,14 @@ func enableHTTPStubs() {
     stub(condition: isHost("currry.xyz") && isPath("/api/lists/1/members/101") && isMethodDELETE()) { _ in
         return OHHTTPStubsResponse(jsonObject : [], statusCode: 200, headers: nil)
     }
+    
+    //Relationship
+    stub(condition: isHost("currry.xyz") && isPath("/api/relationship") && isMethodDELETE()) { _ in
+        return OHHTTPStubsResponse(jsonObject : [], statusCode: 200, headers: nil)
+    }
+    stub(condition: isHost("currry.xyz") && isPath("/api/relationship") && isMethodPOST()) { _ in
+        return OHHTTPStubsResponse(jsonObject : [], statusCode: 200, headers: nil)
+    }
 }
 
 func disableHTTPStubs() {

--- a/Turmeric/Classes/Models/Relationship.swift
+++ b/Turmeric/Classes/Models/Relationship.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Alamofire
+import SwiftyJSON
+
+class Relationship {
+    static func createRelationship(userID: Int, handler: @escaping (() -> Void)) {
+        let parameters: [String: Any] = [
+            "followed_id": userID
+        ]
+        
+        APIClient.request(endpoint: Endpoint.RelationshipCreate, parameters: parameters) { json in
+            handler()
+        }
+    }
+    
+    static func destroyRelationship(userID: Int, handler: @escaping (() -> Void)) {
+        let parameters: [String: Any] = [
+            "followed_id": userID
+        ]
+        
+        APIClient.request(endpoint: Endpoint.RelationshipDestroy, parameters: parameters) { json in
+            handler()
+        }
+    }
+}

--- a/Turmeric/Classes/Models/Relationship.swift
+++ b/Turmeric/Classes/Models/Relationship.swift
@@ -5,7 +5,9 @@ import SwiftyJSON
 class Relationship {
     static func createRelationship(userID: Int, handler: @escaping (() -> Void)) {
         let parameters: [String: Any] = [
-            "followed_id": userID
+            "relationship": [
+                "followed_id": userID
+            ]
         ]
         
         APIClient.request(endpoint: Endpoint.RelationshipCreate, parameters: parameters) { json in
@@ -15,7 +17,9 @@ class Relationship {
     
     static func destroyRelationship(userID: Int, handler: @escaping (() -> Void)) {
         let parameters: [String: Any] = [
-            "followed_id": userID
+            "relationship": [
+                "followed_id": userID
+            ]
         ]
         
         APIClient.request(endpoint: Endpoint.RelationshipDestroy, parameters: parameters) { json in

--- a/Turmeric/Classes/Models/User.swift
+++ b/Turmeric/Classes/Models/User.swift
@@ -11,7 +11,7 @@ class User {
     let followingCount: Int?
     let followersCount: Int?
     let micropostsCount: Int?
-
+    
     init(id: Int, name: String, iconURL: String, email: String? = nil) {
         self.id = id
         self.name = name
@@ -33,7 +33,7 @@ class User {
         self.micropostsCount = json["microposts_count"].int
         self.iconURL = json["icon_url"].string!
     }
-
+    
     static func createUser(parameters: Parameters, handler: @escaping ((User) -> Void)) {
         APIClient.request(endpoint: Endpoint.UsersCreate, parameters: parameters) { json in
             handler(User(json: json["user"]))

--- a/Turmeric/Classes/Views/MembersFollow.swift
+++ b/Turmeric/Classes/Views/MembersFollow.swift
@@ -14,6 +14,7 @@ class MembersFollow: UITableViewCell {
     @IBOutlet weak var name: UILabel!
     
     var isFollowedByMe: Bool!
+    var user: User! // このセルに表示しているユーザ
     
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -34,12 +35,16 @@ class MembersFollow: UITableViewCell {
         // ボタン隠しておく
         self.button.isHidden = true
         
+        // ユーザを覚えておく
+        self.user = user
+        
         // 自分のフォローリストにuserが含まれてるか判定してボタンを書き換える
         User.getMyUser(){ me in
             User.getFollowing(id: me.id){ following in
                 self.button.isHidden = false    // レスポンスが来たので隠すのをやめる
                 
                 self.isFollowedByMe = false
+                
                 var title = "フォロー"
                 
                 following?.forEach() { followedByMe in
@@ -51,6 +56,22 @@ class MembersFollow: UITableViewCell {
                 }
                 
                 self.button.setTitle(title, for: UIControlState.normal)
+            }
+        }
+    }
+    
+    // フォロー/アンフォローボタン押下
+    @IBAction func followButtonDidTap(_ sender: AnyObject) {
+        print(user.id)
+        if(self.isFollowedByMe!){
+            Relationship.destroyRelationship(userID: user.id){
+                self.isFollowedByMe = false
+                self.button.setTitle("フォロー", for: UIControlState.normal)
+            }
+        }else{
+            Relationship.createRelationship(userID: user.id){
+                self.isFollowedByMe = true
+                self.button.setTitle("アンフォロー", for: UIControlState.normal)
             }
         }
     }

--- a/Turmeric/Classes/Views/MembersFollow.swift
+++ b/Turmeric/Classes/Views/MembersFollow.swift
@@ -13,6 +13,8 @@ class MembersFollow: UITableViewCell {
     @IBOutlet weak var button: UIButton!
     @IBOutlet weak var name: UILabel!
     
+    var isFollowedByMe: Bool!
+    
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
@@ -24,12 +26,32 @@ class MembersFollow: UITableViewCell {
         // Configure the view for the selected state
     }
     
-    func displayUser(user: User, following:Bool = false){
+    func displayUser(user: User){
         name.text = user.name
         
-        let title: String = following ? "アンフォロー" : "フォロー"
-        button.setTitle(title, for: UIControlState.normal)
-        
         iconImage.af_setImage(withURL: URL(string: user.iconURL)!)
+        
+        // ボタン隠しておく
+        self.button.isHidden = true
+        
+        // 自分のフォローリストにuserが含まれてるか判定してボタンを書き換える
+        User.getMyUser(){ me in
+            User.getFollowing(id: me.id){ following in
+                self.button.isHidden = false    // レスポンスが来たので隠すのをやめる
+                
+                self.isFollowedByMe = false
+                var title = "フォロー"
+                
+                following?.forEach() { followedByMe in
+                    if(followedByMe.id == user.id){
+                        self.isFollowedByMe = true
+                        title = "アンフォロー"
+                        return
+                    }
+                }
+                
+                self.button.setTitle(title, for: UIControlState.normal)
+            }
+        }
     }
 }

--- a/Turmeric/Classes/Views/MembersFollow.xib
+++ b/Turmeric/Classes/Views/MembersFollow.xib
@@ -26,7 +26,11 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ndN-U1-SnQ"/>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ndN-U1-SnQ">
+                        <connections>
+                            <action selector="followButtonDidTap:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="BAy-Ka-CdF"/>
+                        </connections>
+                    </button>
                 </subviews>
                 <constraints>
                     <constraint firstItem="OTs-Xg-ukK" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="6wD-ey-V7F"/>

--- a/Turmeric/Classes/Views/MembersFollow.xib
+++ b/Turmeric/Classes/Views/MembersFollow.xib
@@ -26,9 +26,7 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ndN-U1-SnQ">
-                        <state key="normal" title="フォロー"/>
-                    </button>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ndN-U1-SnQ"/>
                 </subviews>
                 <constraints>
                     <constraint firstItem="OTs-Xg-ukK" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="6wD-ey-V7F"/>

--- a/Turmeric/Storyboards/Profile.storyboard
+++ b/Turmeric/Storyboards/Profile.storyboard
@@ -63,7 +63,7 @@
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="i8V-ir-COL" userLabel="Stat">
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ngK-ft-fVb">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ngK-ft-fVb">
                                         <accessibility key="accessibilityConfiguration" identifier="profileUsetnameLabel"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <nil key="textColor"/>
@@ -77,7 +77,6 @@
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1qL-Po-6Tv" userLabel="FollowingButton">
                                         <accessibility key="accessibilityConfiguration" identifier="profileFollowingCountButton"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                        <state key="normal" title="100"/>
                                         <connections>
                                             <segue destination="6U7-mI-ayN" kind="push" identifier="following" id="Qkf-wJ-qOt"/>
                                         </connections>
@@ -90,12 +89,11 @@
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mQj-hl-Bd0" userLabel="FollowersButton">
                                         <accessibility key="accessibilityConfiguration" identifier="profileFollowersCountButton"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                        <state key="normal" title="100"/>
                                         <connections>
                                             <segue destination="3df-Ct-SUt" kind="push" identifier="followers" id="L9h-7o-iQe"/>
                                         </connections>
                                     </button>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5,100" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="siK-Xr-AGZ">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="siK-Xr-AGZ">
                                         <accessibility key="accessibilityConfiguration" identifier="profileMicropostsCountLabel"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>

--- a/TurmericTests/Models/RelationshipTests.swift
+++ b/TurmericTests/Models/RelationshipTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+import OHHTTPStubs
+import Nimble
+
+@testable import Turmeric
+
+class RelationshipTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        enableHTTPStubs()
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+        OHHTTPStubs.removeAllStubs()
+        logout()
+    }
+
+    func testFollow() {
+        login()
+        
+        waitUntil { done in
+            Relationship.createRelationship(userID: 102){
+                done()
+            }
+        }
+    }
+    
+    func testUnfollow() {
+        login()
+        
+        waitUntil { done in
+            Relationship.destroyRelationship(userID: 101){
+                done()
+            }
+        }
+    }
+}

--- a/TurmericUITests/ProfileUITests.swift
+++ b/TurmericUITests/ProfileUITests.swift
@@ -44,24 +44,47 @@ class ProfileUITests: XCTestCase {
     }
     
     func testMyFollowers(){
+        // ページに移動
         let app = XCUIApplication()
         app.launch()
-        
         app.tabBars.buttons["プロフィール"].tap()
         app.buttons["profileFollowersCountButton"].tap()
         
+        // ユーザ名とフォロー/アンフォローボタンを確認
         XCTAssert(app.staticTexts["ry023"].exists)
+        XCTAssert(app.tables.cells.containing(.staticText, identifier:"ry023").buttons["アンフォロー"].exists)
+        
         XCTAssert(app.staticTexts["shimoju"].exists)
+        XCTAssert(app.tables.cells.containing(.staticText, identifier:"shimoju").buttons["フォロー"].exists)
+        
+        //アンフォローしたらフォローボタンに変わる
+        app.tables.cells.containing(.staticText, identifier:"ry023").buttons["アンフォロー"].tap()
+        XCTAssert(app.tables.cells.containing(.staticText, identifier:"ry023").buttons["フォロー"].exists)
+        
+        //フォローしたらアンフォローボタンに変わる
+        app.tables.cells.containing(.staticText, identifier:"shimoju").buttons["フォロー"].tap()
+        XCTAssert(app.tables.cells.containing(.staticText, identifier:"shimoju").buttons["アンフォロー"].exists)
     }
     
     func testMyFollowing(){
+        // ページに移動
         let app = XCUIApplication()
         app.launch()
-        
         app.tabBars.buttons["プロフィール"].tap()
         app.buttons["profileFollowingCountButton"].tap()
         
+        // ユーザ名とアンフォローボタンを確認
         XCTAssert(app.staticTexts["ry023"].exists)
-        XCTAssert(!app.staticTexts["shimoju"].exists)
+        XCTAssert(app.tables.cells.containing(.staticText, identifier:"ry023").buttons["アンフォロー"].exists)
+        
+        XCTAssert(!app.staticTexts["shimoju"].exists)   // フォローしていないユーザは表示されない
+        
+        //アンフォローしたらフォローボタンに変わる
+        app.tables.cells.containing(.staticText, identifier:"ry023").buttons["アンフォロー"].tap()
+        XCTAssert(app.tables.cells.containing(.staticText, identifier:"ry023").buttons["フォロー"].exists)
+        
+        //フォローしたらアンフォローボタンに変わる
+        app.tables.cells.containing(.staticText, identifier:"ry023").buttons["フォロー"].tap()
+        XCTAssert(app.tables.cells.containing(.staticText, identifier:"ry023").buttons["アンフォロー"].exists)
     }
 }


### PR DESCRIPTION
### やったこと
- [x] Relationshipモデルを作成
- [x] `POST /api/relationships`と`DELETE /api/relationship`に対するAPI部を実装
- [x] フォロー/アンフォローボタンを実装
- [x] テスト
  - [x] stub
  - [x] Unitテスト
    - APIアクセスができるか
  - [x] UIテスト
    - フォロー/アンフォローボタンを押した後、ボタン表示が切り替わるか
### やってないこと

「アンフォローボタンを押すと、次回フォローページを開いた時にそのユーザが表示されなくなっている」というUITestはできていません。

これをするには、ユーザをアンフォローする`DELETE /api/relationship`にアクセスした後、ユーザのフォロー一覧を表示する`GET /api/users/1/following`の結果が変化する必要があります。
現段階でのstubはそれをするほど賢くできていないため、stubを賢く変更しない限りここを自動化は難しいと思われます。
申し訳ないですが、ここでは開発時間の兼ね合いから、手動で実サーバのAPIにアクセスすることで確認して欲しいです。
