### PR TITLE
フィードにユーザー情報を表示する

### DIFF
--- a/Turmeric/Classes/Controllers/FeedViewController.swift
+++ b/Turmeric/Classes/Controllers/FeedViewController.swift
@@ -40,9 +40,10 @@ class FeedViewController: UITableViewController, IndicatorInfoProvider {
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "micropostCell", for: indexPath) as! MicropostCell
-        cell.name.text = "Example User"
-        cell.content.text = self.microposts[indexPath.row].content
-        cell.profileImage.af_setImage(withURL: URL(string: "https://secure.gravatar.com/avatar/b58996c504c5638798eb6b511e6f49af?s=80")!)
+        let micropost = self.microposts[indexPath.row]
+        cell.name.text = micropost.user.name
+        cell.content.text = micropost.content
+        cell.profileImage.af_setImage(withURL: micropost.user.iconURL)
 
         return cell
     }

--- a/Turmeric/Classes/Models/Micropost.swift
+++ b/Turmeric/Classes/Models/Micropost.swift
@@ -7,12 +7,14 @@ class Micropost {
     let userId: Int
     let content: String
     let picture: URL?
+    let user: User
 
-    init(id: Int, userId: Int, content: String, picture: URL?) {
+    init(id: Int, userId: Int, content: String, picture: URL?, user: User) {
         self.id = id
         self.userId = userId
         self.content = content
         self.picture = picture
+        self.user = user
     }
 
     init(json: JSON) {
@@ -24,6 +26,7 @@ class Micropost {
         } else {
             self.picture = nil
         }
+        self.user = User(json: json["user"])
     }
 
     static func postMicropost(parameters: Parameters, handler: @escaping ((Micropost) -> Void)) {

--- a/Turmeric/Fixtures/MicropostsPost.json
+++ b/Turmeric/Fixtures/MicropostsPost.json
@@ -5,6 +5,15 @@
         "content": "I just ate an orange!",
         "user_id": 1,
         "created_at": "2016-09-30T09:41:24.000Z",
-        "picture": null
+        "picture": null,
+        "user": {
+            "id": 1,
+            "name": "Example User",
+            "activated": true,
+            "icon_url": "https://secure.gravatar.com/avatar/03ea78c0884c9ac0f73e6af7b9649e90?s=80",
+            "following_count": 2,
+            "followers_count": 3,
+            "microposts_count": 35
+        }
     }
 }

--- a/Turmeric/Fixtures/MicropostsShow.json
+++ b/Turmeric/Fixtures/MicropostsShow.json
@@ -4,6 +4,15 @@
         "content": "I just ate an orange!",
         "user_id": 1,
         "created_at": "2016-09-30T09:41:24.000Z",
-        "picture": null
+        "picture": null,
+        "user": {
+            "id": 1,
+            "name": "Example User",
+            "activated": true,
+            "icon_url": "https://secure.gravatar.com/avatar/03ea78c0884c9ac0f73e6af7b9649e90?s=80",
+            "following_count": 2,
+            "followers_count": 3,
+            "microposts_count": 34
+        }
     }
 }

--- a/Turmeric/Fixtures/MicropostsShow_withPicture.json
+++ b/Turmeric/Fixtures/MicropostsShow_withPicture.json
@@ -4,6 +4,15 @@
         "content": "With picture",
         "user_id": 2,
         "created_at": "2016-10-03T12:41:24.000Z",
-        "picture": "https://example.com/picture.jpg"
+        "picture": "https://example.com/picture.jpg",
+        "user": {
+            "id": 2,
+            "name": "Michael",
+            "activated": true,
+            "icon_url": "https://secure.gravatar.com/avatar/03ea78c0884c9ac0f73e6af7b9649e90?s=80",
+            "following_count": 2,
+            "followers_count": 3,
+            "microposts_count": 34
+        }
     }
 }

--- a/Turmeric/Fixtures/MyFeed.json
+++ b/Turmeric/Fixtures/MyFeed.json
@@ -8,7 +8,7 @@
             "picture": null,
             "user": {
                 "id": 1,
-                "name": "Michael Example",
+                "name": "Example User",
                 "activated": true,
                 "icon_url": "https://secure.gravatar.com/avatar/03ea78c0884c9ac0f73e6af7b9649e90?s=80",
                 "following_count": 2,
@@ -40,12 +40,12 @@
             "picture": null,
             "user": {
                 "id": 7,
-                "name": "Michael Example",
+                "name": "ry023",
                 "activated": true,
                 "icon_url": "https://secure.gravatar.com/avatar/03ea78c0884c9ac0f73e6af7b9649e90?s=80",
-                "following_count": 2,
-                "followers_count": 3,
-                "microposts_count": 34
+                "following_count": 20,
+                "followers_count": 30,
+                "microposts_count": 340
             }
         },
         {
@@ -56,12 +56,12 @@
             "picture": null,
             "user": {
                 "id": 26,
-                "name": "Michael Example",
+                "name": "ogidow",
                 "activated": true,
                 "icon_url": "https://secure.gravatar.com/avatar/03ea78c0884c9ac0f73e6af7b9649e90?s=80",
-                "following_count": 2,
-                "followers_count": 3,
-                "microposts_count": 34
+                "following_count": 30,
+                "followers_count": 34,
+                "microposts_count": 100
             }
         },
         {
@@ -104,12 +104,12 @@
             "picture": null,
             "user": {
                 "id": 78,
-                "name": "Michael Example",
+                "name": "shimoju",
                 "activated": true,
                 "icon_url": "https://secure.gravatar.com/avatar/03ea78c0884c9ac0f73e6af7b9649e90?s=80",
-                "following_count": 2,
-                "followers_count": 3,
-                "microposts_count": 34
+                "following_count": 50,
+                "followers_count": 60,
+                "microposts_count": 70
             }
         },
         {
@@ -120,7 +120,7 @@
             "picture": null,
             "user": {
                 "id": 10,
-                "name": "Michael Example",
+                "name": "sun",
                 "activated": true,
                 "icon_url": "https://secure.gravatar.com/avatar/03ea78c0884c9ac0f73e6af7b9649e90?s=80",
                 "following_count": 2,
@@ -136,7 +136,7 @@
             "picture": null,
             "user": {
                 "id": 100,
-                "name": "Michael Example",
+                "name": "mataku",
                 "activated": true,
                 "icon_url": "https://secure.gravatar.com/avatar/03ea78c0884c9ac0f73e6af7b9649e90?s=80",
                 "following_count": 2,
@@ -152,7 +152,7 @@
             "picture": null,
             "user": {
                 "id": 2,
-                "name": "Michael Example",
+                "name": "Michael",
                 "activated": true,
                 "icon_url": "https://secure.gravatar.com/avatar/03ea78c0884c9ac0f73e6af7b9649e90?s=80",
                 "following_count": 2,

--- a/Turmeric/Fixtures/MyFeed.json
+++ b/Turmeric/Fixtures/MyFeed.json
@@ -5,70 +5,160 @@
             "content": "Writing a short test",
             "user_id": 1,
             "created_at": "2016-10-04T08:18:33.000Z",
-            "picture": null
+            "picture": null,
+            "user": {
+                "id": 1,
+                "name": "Michael Example",
+                "activated": true,
+                "icon_url": "https://secure.gravatar.com/avatar/03ea78c0884c9ac0f73e6af7b9649e90?s=80",
+                "following_count": 2,
+                "followers_count": 3,
+                "microposts_count": 34
+            }
         },
         {
             "id": 7,
             "content": "I'm sorry. Your words made sense, but your sarcastic tone did not",
             "user_id": 6,
             "created_at": "2016-10-02T08:08:33.000Z",
-            "picture": null
+            "picture": null,
+            "user": {
+                "id": 6,
+                "name": "Lana Kane",
+                "activated": true,
+                "icon_url": "https://secure.gravatar.com/avatar/de9a58df9617af487e8b28dbb3aa50de?s=80",
+                "following_count": 1,
+                "followers_count": 1,
+                "microposts_count": 2
+            }
         },
         {
             "id": 1,
             "content": "I just ate an orange!",
             "user_id": 7,
             "created_at": "2016-10-01T08:08:33.000Z",
-            "picture": null
+            "picture": null,
+            "user": {
+                "id": 7,
+                "name": "Michael Example",
+                "activated": true,
+                "icon_url": "https://secure.gravatar.com/avatar/03ea78c0884c9ac0f73e6af7b9649e90?s=80",
+                "following_count": 2,
+                "followers_count": 3,
+                "microposts_count": 34
+            }
         },
         {
             "id": 3,
             "content": "Sad cats are sad: http://youtu.be/PKffm2ul4dk",
             "user_id": 26,
             "created_at": "2016-09-12T06:18:33.000Z",
-            "picture": null
+            "picture": null,
+            "user": {
+                "id": 26,
+                "name": "Michael Example",
+                "activated": true,
+                "icon_url": "https://secure.gravatar.com/avatar/03ea78c0884c9ac0f73e6af7b9649e90?s=80",
+                "following_count": 2,
+                "followers_count": 3,
+                "microposts_count": 34
+            }
         },
         {
             "id": 8,
             "content": "Dude, this van's like, rolling proable cause.",
             "user_id": 37,
             "created_at": "2016-09-04T04:18:33.000Z",
-            "picture": null
+            "picture": null,
+            "user": {
+                "id": 37,
+                "name": "Lana Kane",
+                "activated": true,
+                "icon_url": "https://secure.gravatar.com/avatar/de9a58df9617af487e8b28dbb3aa50de?s=80",
+                "following_count": 1,
+                "followers_count": 1,
+                "microposts_count": 2
+            }
         },
         {
             "id": 9,
             "content": "Dolor qui sapiente voluptatum vel sint.",
             "user_id": 12,
             "created_at": "2016-08-30T08:18:33.000Z",
-            "picture": null
+            "picture": null,
+            "user": {
+                "id": 12,
+                "name": "Michael Example",
+                "activated": true,
+                "icon_url": "https://secure.gravatar.com/avatar/03ea78c0884c9ac0f73e6af7b9649e90?s=80",
+                "following_count": 2,
+                "followers_count": 3,
+                "microposts_count": 34
+            }
         },
         {
             "id": 10,
             "content": "Aut cum assumenda rem quo placeat aut voluptatem.",
             "user_id": 78,
             "created_at": "2016-08-25T08:18:33.000Z",
-            "picture": null
+            "picture": null,
+            "user": {
+                "id": 78,
+                "name": "Michael Example",
+                "activated": true,
+                "icon_url": "https://secure.gravatar.com/avatar/03ea78c0884c9ac0f73e6af7b9649e90?s=80",
+                "following_count": 2,
+                "followers_count": 3,
+                "microposts_count": 34
+            }
         },
         {
             "id": 11,
             "content": "Veniam assumenda voluptatum laborum officia quo.",
             "user_id": 10,
             "created_at": "2016-08-23T08:18:33.000Z",
-            "picture": null
+            "picture": null,
+            "user": {
+                "id": 10,
+                "name": "Michael Example",
+                "activated": true,
+                "icon_url": "https://secure.gravatar.com/avatar/03ea78c0884c9ac0f73e6af7b9649e90?s=80",
+                "following_count": 2,
+                "followers_count": 3,
+                "microposts_count": 34
+            }
         },
         {
             "id": 12,
             "content": "Ut nisi debitis ducimus consequatur deserunt aliquam omnis est et.",
             "user_id": 100,
             "created_at": "2016-08-10T08:18:33.000Z",
-            "picture": null
+            "picture": null,
+            "user": {
+                "id": 100,
+                "name": "Michael Example",
+                "activated": true,
+                "icon_url": "https://secure.gravatar.com/avatar/03ea78c0884c9ac0f73e6af7b9649e90?s=80",
+                "following_count": 2,
+                "followers_count": 3,
+                "microposts_count": 34
+            }
         },
         {
             "id": 33,
             "content": "Rerum ut laborum at ab in itaque quos.",
             "user_id": 2,
             "created_at": "2016-07-23T08:18:33.000Z",
-            "picture": null
+            "picture": null,
+            "user": {
+                "id": 2,
+                "name": "Michael Example",
+                "activated": true,
+                "icon_url": "https://secure.gravatar.com/avatar/03ea78c0884c9ac0f73e6af7b9649e90?s=80",
+                "following_count": 2,
+                "followers_count": 3,
+                "microposts_count": 34
+            }
         }
     ]
 }

--- a/TurmericTests/Models/MicropostTests.swift
+++ b/TurmericTests/Models/MicropostTests.swift
@@ -34,6 +34,8 @@ class MicropostTests: XCTestCase {
                 XCTAssertEqual(1, response.userId)
                 XCTAssertEqual("I just ate an orange!", response.content)
                 XCTAssertNil(response.picture)
+                // マイクロポストにユーザー情報が含まれているかテスト
+                XCTAssertEqual("Example User", response.user.name)
                 done()
             }
         }
@@ -43,6 +45,7 @@ class MicropostTests: XCTestCase {
                 XCTAssertEqual(2, response.userId)
                 XCTAssertEqual("With picture", response.content)
                 XCTAssertEqual("https://example.com/picture.jpg", response.picture?.absoluteString)
+                XCTAssertEqual("Michael", response.user.name)
                 done()
             }
         }

--- a/TurmericTests/Models/MicropostTests.swift
+++ b/TurmericTests/Models/MicropostTests.swift
@@ -22,6 +22,7 @@ class MicropostTests: XCTestCase {
         waitUntil { done in
             Micropost.postMicropost(parameters: parameters){ response in
                 XCTAssertEqual("I just ate an orange!", response.content)
+                XCTAssertEqual("Example User", response.user.name)
                 done()
             }
         }

--- a/TurmericTests/Models/UserTests.swift
+++ b/TurmericTests/Models/UserTests.swift
@@ -67,6 +67,7 @@ class UserTests: XCTestCase {
                     XCTAssertNotNil($0.id)
                     XCTAssertNotNil($0.content)
                     XCTAssertNotNil($0.userId)
+                    XCTAssertNotNil($0.user.name)
                 }
                 done()
             }

--- a/TurmericUITests/FeedUITests.swift
+++ b/TurmericUITests/FeedUITests.swift
@@ -17,8 +17,14 @@ class FeedUITests: XCTestCase {
         app.tabBars.buttons["ホーム"].tap()
         let micropostCells = app.tables.cells
         XCTAssertEqual(10, micropostCells.count)
-        XCTAssert(micropostCells.staticTexts["Writing a short test"].exists)
-        XCTAssert(micropostCells.staticTexts["Example User"].exists)
+        // 最初のセル
+        let firstCell = micropostCells.element(boundBy: 0)
+        XCTAssert(firstCell.staticTexts["Example User"].exists)
+        XCTAssert(firstCell.staticTexts["Writing a short test"].exists)
+        // 最後のセル
+        let lastCell = micropostCells.element(boundBy: micropostCells.count - 1)
+        XCTAssert(lastCell.staticTexts["Michael"].exists)
+        XCTAssert(lastCell.staticTexts["Rerum ut laborum at ab in itaque quos."].exists)
     }
 
     // リストフィード(リストに追加されたユーザーの投稿)
@@ -31,8 +37,14 @@ class FeedUITests: XCTestCase {
         let micropostCells = app.tables.cells
         // TODO: リストのフィードが取得できるようになったら個数やテキストを変更する
         XCTAssertEqual(10, micropostCells.count)
-        XCTAssert(micropostCells.staticTexts["Writing a short test"].exists)
-        XCTAssert(micropostCells.staticTexts["Example User"].exists)
+        // 最初のセル
+        let firstCell = micropostCells.element(boundBy: 0)
+        XCTAssert(firstCell.staticTexts["Example User"].exists)
+        XCTAssert(firstCell.staticTexts["Writing a short test"].exists)
+        // 最後のセル
+        let lastCell = micropostCells.element(boundBy: micropostCells.count - 1)
+        XCTAssert(lastCell.staticTexts["Michael"].exists)
+        XCTAssert(lastCell.staticTexts["Rerum ut laborum at ab in itaque quos."].exists)
     }
 
     // プロフィールフィード(プロフィールページの自分の投稿)
@@ -42,7 +54,13 @@ class FeedUITests: XCTestCase {
         let micropostCells = app.tables.cells
         // TODO: プロフィールフィードが取得できるようになったら個数やテキストを変更する
         XCTAssertEqual(10, micropostCells.count)
-        XCTAssert(micropostCells.staticTexts["Writing a short test"].exists)
-        XCTAssert(micropostCells.staticTexts["Example User"].exists)
+        // 最初のセル
+        let firstCell = micropostCells.element(boundBy: 0)
+        XCTAssert(firstCell.staticTexts["Example User"].exists)
+        XCTAssert(firstCell.staticTexts["Writing a short test"].exists)
+        // 最後のセル
+        let lastCell = micropostCells.element(boundBy: micropostCells.count - 1)
+        XCTAssert(lastCell.staticTexts["Michael"].exists)
+        XCTAssert(lastCell.staticTexts["Rerum ut laborum at ab in itaque quos."].exists)
     }
 }


### PR DESCRIPTION
マイクロポストにユーザー情報を含むようにした https://github.com/ogidow/railstutorial/pull/89 ので、これを使ってフィードに名前やアイコンを表示します。
- Micropostモデルに`user`プロパティを追加してユーザー情報を持たせました
  - `micropost.user.name`のようにアクセスできて便利
- UIテストはアイコン画像があるか確認したかったんだけどできなかった…

![2016-10-12 11 11 11](https://cloud.githubusercontent.com/assets/1928324/19295022/9c24e43e-906c-11e6-9d66-cfa7c430878b.png)
