### PR TITLE
 APIクライアントのエラーハンドリング

### DIFF
--- a/Turmeric.xcodeproj/project.pbxproj
+++ b/Turmeric.xcodeproj/project.pbxproj
@@ -331,8 +331,8 @@
 		5242ABF21D98F16A0095D4F4 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
-				52685A261D990E4400FEC0A7 /* APIClient.swift */,
 				725B13121DA2450C00A12006 /* Stub.swift */,
+				52685A261D990E4400FEC0A7 /* APIClient.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";

--- a/Turmeric/Classes/Controllers/FeedViewController.swift
+++ b/Turmeric/Classes/Controllers/FeedViewController.swift
@@ -21,9 +21,13 @@ class FeedViewController: UITableViewController, IndicatorInfoProvider {
         // AppDelegateからログイン完了の通知を受けたらフィードを取得する
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
         appDelegate.loginDispatch.notify(queue: DispatchQueue.main, execute: {
-            User.getMyFeed { feed in
-                self.microposts = feed!
-                self.tableView.reloadData()
+            User.getMyFeed { response in
+                switch response {
+                case .Success(let feed):
+                    self.microposts = feed!
+                    self.tableView.reloadData()
+                default: break
+                }
             }
         })
     }

--- a/Turmeric/Classes/Controllers/HomeViewController.swift
+++ b/Turmeric/Classes/Controllers/HomeViewController.swift
@@ -9,9 +9,13 @@ class HomeViewController: ButtonBarPagerTabStripViewController {
         // AppDelegateからログイン完了の通知を受けたらリストを取得する
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
         appDelegate.loginDispatch.notify(queue: DispatchQueue.main, execute: {
-            User.getMyLists() { lists in
-                self.lists = lists!
-                self.reloadPagerTabStripView()
+            User.getMyLists() { response in
+                switch response {
+                case .Success(let lists):
+                    self.lists = lists!
+                    self.reloadPagerTabStripView()
+                default: break
+                }
             }
         })
     }

--- a/Turmeric/Classes/Controllers/ListAddMemberViewController.swift
+++ b/Turmeric/Classes/Controllers/ListAddMemberViewController.swift
@@ -23,13 +23,21 @@ class ListAddMemberViewController: UIViewController, UITableViewDelegate, UITabl
         super.viewDidLoad()
         self.tableView.register(UINib(nibName: "MembersAddCell", bundle: nil), forCellReuseIdentifier: "membersAddCell")
 
-        User.getMyUser(){ me in
-            User.getFollowing(id: me.id){ following in
-                // すでにリストに追加されているユーザは取り除く
-                self.followings = following!.filter() {user in
-                    !self.members.contains(where: {$0.id == user.id})
+        User.getMyUser(){ getMyUserResponse in
+            switch getMyUserResponse {
+            case .Success(let me):
+                User.getFollowing(id: me.id){ getFollowingResponse in
+                    switch getFollowingResponse {
+                    case .Success(let following):
+                        // すでにリストに追加されているユーザは取り除く
+                        self.followings = following!.filter() {user in
+                            !self.members.contains(where: {$0.id == user.id})
+                        }
+                        self.tableView.reloadData()
+                    default: break
+                    }
                 }
-                self.tableView.reloadData()
+            default: break
             }
         }
 

--- a/Turmeric/Classes/Controllers/ListDetailViewController.swift
+++ b/Turmeric/Classes/Controllers/ListDetailViewController.swift
@@ -65,13 +65,23 @@ class ListDetailViewController: UIViewController, UITableViewDelegate, UITableVi
 
     private func requestData() {
         List.getList(id: self.selectedListId!) { response in
-            self.list = response
-            self.listNameLabel.text = response.name
+            switch response {
+            case .Success(let list):
+                self.list = list
+                self.listNameLabel.text = list.name
+            default: break
+            }
+            
         }
 
         List.getMembers(id: self.selectedListId!) { response in
-            self.members = response
-            self.tableView.reloadData()
+            switch response {
+            case .Success(let members):
+                self.members = members
+                self.tableView.reloadData()
+            default: break
+            }
+            
         }
     }
 }

--- a/Turmeric/Classes/Controllers/ListEditViewController.swift
+++ b/Turmeric/Classes/Controllers/ListEditViewController.swift
@@ -33,8 +33,12 @@ class ListEditViewController: UIViewController, UITableViewDelegate, UITableView
 
         self.deleteMembers.forEach{
             group.enter()
-            List.deleteMember(listId: self.list!.id, memberId: $0.id) {
-                group.leave()
+            List.deleteMember(listId: self.list!.id, memberId: $0.id) { response in
+                switch response {
+                case .Success:
+                   group.leave()
+                default: break
+                }
             }
         }
 
@@ -118,13 +122,21 @@ class ListEditViewController: UIViewController, UITableViewDelegate, UITableView
 
     private func requestData() {
         List.getList(id: self.selectedListId!) { response in
-            self.list = response
-            self.listNameField.text = response.name
+            switch response {
+            case .Success(let list):
+                self.list = list
+                self.listNameField.text = list.name
+            default: break
+            }
         }
 
         List.getMembers(id: self.selectedListId!) { response in
-            self.members = response
-            self.tableView.reloadData()
+            switch response {
+            case .Success(let members):
+                self.members = members
+                self.tableView.reloadData()
+            default: break
+            }
         }
     }
 }

--- a/Turmeric/Classes/Controllers/ListManagementViewController.swift
+++ b/Turmeric/Classes/Controllers/ListManagementViewController.swift
@@ -18,8 +18,12 @@ class ListManagementViewController: UITableViewController{
         
         self.deleteLists.forEach {
             group.enter()
-            List.deleteList(id: $0.id) {
-                group.leave()
+            List.deleteList(id: $0.id) {response in
+                switch response {
+                case .Success:
+                    group.leave()
+                default: break
+                }
             }
         }
         //選択されたリストが全て削除し終わったら画面遷移する
@@ -41,9 +45,14 @@ class ListManagementViewController: UITableViewController{
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         User.getMyLists { response in
-            self.myLists = response!
-            self.tableView.reloadData()
+            switch response {
+            case .Success(let lists):
+                self.myLists = lists!
+                self.tableView.reloadData()
+            default: break
+            }
         }
+        
         self.tableView.tableFooterView = UIView()
     }
     

--- a/Turmeric/Classes/Controllers/ListViewController.swift
+++ b/Turmeric/Classes/Controllers/ListViewController.swift
@@ -61,9 +61,13 @@ class ListViewController: UITableViewController {
     }
     
     private func requestData(){
-        User.getMyLists { lists in
-            self.lists = lists
-            self.tableView.reloadData()
+        User.getMyLists { response in
+            switch response {
+            case .Success(let lists):
+                self.lists = lists
+                self.tableView.reloadData()
+            default: break
+            }
         }
     }
 }

--- a/Turmeric/Classes/Controllers/OthersProfileViewController.swift
+++ b/Turmeric/Classes/Controllers/OthersProfileViewController.swift
@@ -39,23 +39,33 @@ class OthersProfileViewController: UIViewController {
         
         
         // 自分がフォローしてるか取得してボタンを変更
-        User.getMyUser(){ me in
-            User.getFollowing(id: me.id){ following in
-                self.followButton.isHidden = false    // レスポンスが来たので隠すのをやめる
-                
-                self.isFollowedByMe = false
-                
-                var title = "フォロー"
-                
-                following?.forEach() { followedByMe in
-                    if(followedByMe.id == self.user?.id){
-                        self.isFollowedByMe = true
-                        title = "アンフォロー"
-                        return
+        User.getMyUser(){ getMyUserResponse in
+            switch getMyUserResponse {
+            case .Success(let me):
+                User.getFollowing(id: me.id){ getFollowingResponse in
+                    switch getFollowingResponse {
+                    case .Success(let following):
+                        self.followButton.isHidden = false    // レスポンスが来たので隠すのをやめる
+                        
+                        self.isFollowedByMe = false
+                        
+                        var title = "フォロー"
+                        
+                        following?.forEach() { followedByMe in
+                            if(followedByMe.id == self.user?.id){
+                                self.isFollowedByMe = true
+                                title = "アンフォロー"
+                                return
+                            }
+                        }
+                        
+                        self.followButton.setTitle(title, for: UIControlState.normal)
+                    default: break
+
                     }
                 }
-                
-                self.followButton.setTitle(title, for: UIControlState.normal)
+
+            default: break
             }
         }
     }
@@ -80,6 +90,7 @@ class OthersProfileViewController: UIViewController {
             // 次のvcにフォローユーザたちを表示するように依頼
             vc.displayStyle = UsersViewController.DisplayStyle.Following(user!.id)
             break
+
         case "followers":
             let vc = segue.destination as! UsersViewController
             
@@ -94,14 +105,23 @@ class OthersProfileViewController: UIViewController {
     @IBAction func followButtonDidTap(_ sender: AnyObject) {
         // フォロー/アンフォローボタンを押下
         if(self.isFollowedByMe!){
-            Relationship.destroyRelationship(userID: self.user!.id){
-                self.isFollowedByMe = false
-                self.followButton.setTitle("フォロー", for: UIControlState.normal)
+            Relationship.destroyRelationship(userID: self.user!.id){ response in
+                switch response {
+                case .Success:
+                    self.isFollowedByMe = false
+                    self.followButton.setTitle("フォロー", for: UIControlState.normal)
+                default: break
+                }
             }
         }else{
-            Relationship.createRelationship(userID: self.user!.id){
-                self.isFollowedByMe = true
-                self.followButton.setTitle("アンフォロー", for: UIControlState.normal)
+            Relationship.createRelationship(userID: self.user!.id){ response in
+                switch response {
+                case .Success:
+                    self.isFollowedByMe = true
+                    self.followButton.setTitle("アンフォロー", for: UIControlState.normal)
+                default: break
+                }
+                
             }
         }
 

--- a/Turmeric/Classes/Controllers/PostViewController.swift
+++ b/Turmeric/Classes/Controllers/PostViewController.swift
@@ -20,13 +20,17 @@ class PostViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         // アイコン表示
-        User.getMyUser(){ user in
-            do {
-                let data = try Data(contentsOf: user.iconURL )
-                self.iconImageView.image = UIImage(data: data)
-            } catch {
-                //画像がダウンロードできなかった
-            }
+        User.getMyUser(){ response in
+            switch response {
+            case .Success(let user):
+                do {
+                    let data = try Data(contentsOf: user.iconURL )
+                    self.iconImageView.image = UIImage(data: data)
+                } catch {
+                    //画像がダウンロードできなかった
+                }
+            default: break
+            }            
         }
     }
 

--- a/Turmeric/Classes/Controllers/ProfileViewController.swift
+++ b/Turmeric/Classes/Controllers/ProfileViewController.swift
@@ -22,25 +22,30 @@ class ProfileViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        User.getMyUser(){ user in
-            self.me = user
-            
-            self.usernameLabel.text = user.name
-
-            if let micropostCount = user.micropostsCount, let followersCount = user.followersCount, let followingCount = user.followingCount {
-                self.micropostsLabel.text = micropostCount.description
-
-                self.followersButton.setTitle(followersCount.description, for: UIControlState.normal)
-                self.followingButton.setTitle(followingCount.description, for: UIControlState.normal)
-            }
-
-            do {
-                let data = try Data(contentsOf: user.iconURL )
-                self.profileImage.image = UIImage(data: data)
-            } catch {
-                //画像がダウンロードできなかった
+        User.getMyUser(){ response in
+            switch response {
+            case .Success(let user):
+                self.me = user
+                
+                self.usernameLabel.text = user.name
+                
+                if let micropostCount = user.micropostsCount, let followersCount = user.followersCount, let followingCount = user.followingCount {
+                    self.micropostsLabel.text = micropostCount.description
+                    
+                    self.followersButton.setTitle(followersCount.description, for: UIControlState.normal)
+                    self.followingButton.setTitle(followingCount.description, for: UIControlState.normal)
+                }
+                
+                do {
+                    let data = try Data(contentsOf: user.iconURL )
+                    self.profileImage.image = UIImage(data: data)
+                } catch {
+                    //画像がダウンロードできなかった
+                }
+            default: break
             }
         }
+            
     }
 
     override func didReceiveMemoryWarning() {

--- a/Turmeric/Classes/Controllers/UsersViewController.swift
+++ b/Turmeric/Classes/Controllers/UsersViewController.swift
@@ -36,14 +36,23 @@ class UsersViewController: UITableViewController {
         // フォロー一覧かフォロワー一覧かで読み込む内容を判別
         switch self.displayStyle! {
         case let UsersViewController.DisplayStyle.Following(userID):
-            User.getFollowing(id: userID){ following in
-                self.displayUsers = following!
-                self.tableView.reloadData()
+            User.getFollowing(id: userID){ response in
+                switch response {
+                case .Success(let following):
+                    self.displayUsers = following!
+                    self.tableView.reloadData()
+                default: break
+                }
             }
         case let UsersViewController.DisplayStyle.Followers(userID):
-            User.getFollowers(id: userID){ followers in
-                self.displayUsers = followers!
-                self.tableView.reloadData()
+            User.getFollowers(id: userID){ response in
+                switch response {
+                case .Success(let followers):
+                    self.displayUsers = followers!
+                    self.tableView.reloadData()
+                default: break
+                }
+                
             }
         }
     }

--- a/Turmeric/Classes/Helpers/APIClient.swift
+++ b/Turmeric/Classes/Helpers/APIClient.swift
@@ -151,8 +151,8 @@ enum Endpoint {
 }
 
 enum APIResponse<ResultType> {
-    case Success(ResultType)
-    case ValidationError(JSON)
-    case Unauthorized
-    case RequestFailure
+    case Success(ResultType)   //リクエスト成功
+    case ValidationError(JSON) //バリデーションエラー
+    case Unauthorized          //認証エラー
+    case RequestFailure        //その他のエラー
 }

--- a/Turmeric/Classes/Models/List.swift
+++ b/Turmeric/Classes/Models/List.swift
@@ -17,48 +17,79 @@ class List {
     }
     
     static func getList(id: Int, handler: @escaping ((List) -> Void)) {
-        APIClient.request(endpoint: Endpoint.ListsShow(id)) { json in
-            handler(List(json: json["list"]))
+        APIClient.request(endpoint: Endpoint.ListsShow(id)) { response in
+            switch response {
+            case .Success(let json):
+                handler(List(json: json["list"]))
+            default: break
+            }
+            
         }
     }
     
     static func getMembers(id:Int, handler: @escaping ([User]) -> Void) {
-        APIClient.request(endpoint: Endpoint.ListsMembers(id)) { json in
-            let members: [User] = json["members"].array!.map {
-                User(json: $0)
+        APIClient.request(endpoint: Endpoint.ListsMembers(id)) { response in
+            switch response {
+            case .Success(let json):
+                let members: [User] = json["members"].array!.map {
+                    User(json: $0)
                 }
-            handler(members)
+                handler(members)
+            default: break
+            }
+            
         }
     }
     
     static func update(id: Int, parameters: Parameters, handler: @escaping ((List) -> Void)){
-        APIClient.request(endpoint: Endpoint.ListsUpdate(id), parameters: parameters) { json in
-            handler(List(json: json["list"]))
+        APIClient.request(endpoint: Endpoint.ListsUpdate(id), parameters: parameters) { response in
+            switch response {
+            case .Success(let json):
+                handler(List(json: json["list"]))
+            default: break
+            }
+            
         }
     }
     
     static func deleteMember(listId: Int, memberId: Int, handler: @escaping (Void) -> Void) {
-        APIClient.request(endpoint: Endpoint.ListsDeleteMember(listId, memberId)) { json in
-            handler()
+        APIClient.request(endpoint: Endpoint.ListsDeleteMember(listId, memberId)) { response in
+            switch response {
+            case .Success(let json):
+                handler()
+            default: break
+            }
+            
         }
     }
     
     static func addMember(id: Int, parameters: Parameters, handler: @escaping (Void) -> Void) {
-        APIClient.request(endpoint: Endpoint.ListsAddMember(id), parameters: parameters) { json in
-            handler()
+        APIClient.request(endpoint: Endpoint.ListsAddMember(id), parameters: parameters) { response in
+            switch response {
+            case .Success(let json):
+                handler()
+            default: break
+            }
         }
     }
     
     static func deleteList(id: Int, handler: @escaping (Void) -> Void) {
-        APIClient.request(endpoint: Endpoint.ListsDelete(id)) { json in
-            handler()
+        APIClient.request(endpoint: Endpoint.ListsDelete(id)) { response in
+            switch response {
+            case .Success(let json):
+                handler()
+            default: break
+            }
         }
     }
     
     static func createList(parameters: Parameters, handler: @escaping ((List) -> Void)){
-        APIClient.request(endpoint: Endpoint.ListsCreate, parameters: parameters) { json in
-            handler(List(json: json["list"]))
+        APIClient.request(endpoint: Endpoint.ListsCreate, parameters: parameters) { response in
+            switch response {
+            case .Success(let json):
+                handler(List(json: json["list"]))
+            default: break
+            }
         }
     }
-    
 }

--- a/Turmeric/Classes/Models/List.swift
+++ b/Turmeric/Classes/Models/List.swift
@@ -16,78 +16,78 @@ class List {
         self.name = json["name"].string!
     }
     
-    static func getList(id: Int, handler: @escaping ((List) -> Void)) {
+    static func getList(id: Int, handler: @escaping ((APIResponse<List>) -> Void)) {
         APIClient.request(endpoint: Endpoint.ListsShow(id)) { response in
             switch response {
             case .Success(let json):
-                handler(List(json: json["list"]))
+                handler(APIResponse.Success(List(json: json["list"])))
             default: break
             }
             
         }
     }
     
-    static func getMembers(id:Int, handler: @escaping ([User]) -> Void) {
+    static func getMembers(id:Int, handler: @escaping (APIResponse<[User]>) -> Void) {
         APIClient.request(endpoint: Endpoint.ListsMembers(id)) { response in
             switch response {
             case .Success(let json):
                 let members: [User] = json["members"].array!.map {
                     User(json: $0)
                 }
-                handler(members)
+                handler(APIResponse.Success(members))
             default: break
             }
             
         }
     }
     
-    static func update(id: Int, parameters: Parameters, handler: @escaping ((List) -> Void)){
+    static func update(id: Int, parameters: Parameters, handler: @escaping ((APIResponse<List>) -> Void)){
         APIClient.request(endpoint: Endpoint.ListsUpdate(id), parameters: parameters) { response in
             switch response {
             case .Success(let json):
-                handler(List(json: json["list"]))
+                handler(APIResponse.Success(List(json: json["list"])))
             default: break
             }
             
         }
     }
     
-    static func deleteMember(listId: Int, memberId: Int, handler: @escaping (Void) -> Void) {
+    static func deleteMember(listId: Int, memberId: Int, handler: @escaping (APIResponse<Any?>) -> Void) {
         APIClient.request(endpoint: Endpoint.ListsDeleteMember(listId, memberId)) { response in
             switch response {
-            case .Success(let json):
-                handler()
+            case .Success:
+                handler(APIResponse.Success(nil))
             default: break
             }
             
         }
     }
     
-    static func addMember(id: Int, parameters: Parameters, handler: @escaping (Void) -> Void) {
+    static func addMember(id: Int, parameters: Parameters, handler: @escaping (APIResponse<Any?>) -> Void) {
         APIClient.request(endpoint: Endpoint.ListsAddMember(id), parameters: parameters) { response in
             switch response {
-            case .Success(let json):
-                handler()
+            case .Success:
+                handler(APIResponse.Success(nil))
             default: break
             }
         }
     }
     
-    static func deleteList(id: Int, handler: @escaping (Void) -> Void) {
+    static func deleteList(id: Int, handler: @escaping (APIResponse<Any?>) -> Void) {
         APIClient.request(endpoint: Endpoint.ListsDelete(id)) { response in
             switch response {
-            case .Success(let json):
-                handler()
+            case .Success:
+                handler(APIResponse.Success(nil))
             default: break
             }
         }
     }
     
-    static func createList(parameters: Parameters, handler: @escaping ((List) -> Void)){
+    static func createList(parameters: Parameters, handler: @escaping ((APIResponse<List>) -> Void)){
         APIClient.request(endpoint: Endpoint.ListsCreate, parameters: parameters) { response in
             switch response {
             case .Success(let json):
-                handler(List(json: json["list"]))
+                handler(APIResponse.Success(List(json: json["list"])))
             default: break
             }
         }

--- a/Turmeric/Classes/Models/Micropost.swift
+++ b/Turmeric/Classes/Models/Micropost.swift
@@ -29,22 +29,22 @@ class Micropost {
         self.user = User(json: json["user"])
     }
 
-    static func postMicropost(parameters: Parameters, handler: @escaping ((Micropost) -> Void)) {
+    static func postMicropost(parameters: Parameters, handler: @escaping ((APIResponse<Micropost>) -> Void)) {
         APIClient.request(endpoint: Endpoint.MicropostsPost, parameters: parameters) { response in
             switch response {
             case .Success(let json):
-                handler(Micropost(json: json["micropost"]))
+                handler(APIResponse.Success(Micropost(json: json["micropost"])))
             default: break
             }
             
         }
     }
 
-    static func getMicropost(id: Int, handler: @escaping ((Micropost) -> Void)) {
+    static func getMicropost(id: Int, handler: @escaping ((APIResponse<Micropost>) -> Void)) {
         APIClient.request(endpoint: Endpoint.MicropostsShow(id)) { response in
             switch response {
             case .Success(let json):
-                handler(Micropost(json: json["micropost"]))
+                handler(APIResponse.Success(Micropost(json: json["micropost"])))
             default: break
             }
         }

--- a/Turmeric/Classes/Models/Micropost.swift
+++ b/Turmeric/Classes/Models/Micropost.swift
@@ -51,16 +51,20 @@ class Micropost {
     }
 
     static func getFeed(endpoint: Endpoint, handler: @escaping ([Micropost]?) -> Void) {
-        APIClient.request(endpoint: endpoint) { json in
-            let microposts: [Micropost]?
-
-            switch endpoint {
-            case .UsersMicroposts:
-                microposts = (json["microposts"].array?.map { Micropost(json: $0) })
-            default:
-                microposts = (json["feed"].array?.map { Micropost(json: $0) })
+        APIClient.request(endpoint: endpoint) { response in
+            switch response {
+            case .Success(let json):
+                let microposts: [Micropost]?
+                
+                switch endpoint {
+                case .UsersMicroposts:
+                    microposts = (json["microposts"].array?.map { Micropost(json: $0) })
+                default:
+                    microposts = (json["feed"].array?.map { Micropost(json: $0) })
+                }
+                handler(microposts)
+            default: break
             }
-            handler(microposts)
         }
     }
 }

--- a/Turmeric/Classes/Models/Micropost.swift
+++ b/Turmeric/Classes/Models/Micropost.swift
@@ -30,14 +30,23 @@ class Micropost {
     }
 
     static func postMicropost(parameters: Parameters, handler: @escaping ((Micropost) -> Void)) {
-        APIClient.request(endpoint: Endpoint.MicropostsPost, parameters: parameters) { json in
-            handler(Micropost(json: json["micropost"]))
+        APIClient.request(endpoint: Endpoint.MicropostsPost, parameters: parameters) { response in
+            switch response {
+            case .Success(let json):
+                handler(Micropost(json: json["micropost"]))
+            default: break
+            }
+            
         }
     }
 
     static func getMicropost(id: Int, handler: @escaping ((Micropost) -> Void)) {
-        APIClient.request(endpoint: Endpoint.MicropostsShow(id)) { json in
-            handler(Micropost(json: json["micropost"]))
+        APIClient.request(endpoint: Endpoint.MicropostsShow(id)) { response in
+            switch response {
+            case .Success(let json):
+                handler(Micropost(json: json["micropost"]))
+            default: break
+            }
         }
     }
 

--- a/Turmeric/Classes/Models/Relationship.swift
+++ b/Turmeric/Classes/Models/Relationship.swift
@@ -3,7 +3,7 @@ import Alamofire
 import SwiftyJSON
 
 class Relationship {
-    static func createRelationship(userID: Int, handler: @escaping (() -> Void)) {
+    static func createRelationship(userID: Int, handler: @escaping ((APIResponse<Any?>) -> Void)) {
         let parameters: [String: Any] = [
             "relationship": [
                 "followed_id": userID
@@ -12,14 +12,14 @@ class Relationship {
         
         APIClient.request(endpoint: Endpoint.RelationshipCreate, parameters: parameters) { response in
             switch response {
-            case .Success(let json):
-                handler()
+            case .Success:
+                handler(APIResponse.Success(nil))
             default: break
             }
         }
     }
     
-    static func destroyRelationship(userID: Int, handler: @escaping (() -> Void)) {
+    static func destroyRelationship(userID: Int, handler: @escaping ((APIResponse<Any?>) -> Void)) {
         let parameters: [String: Any] = [
             "relationship": [
                 "followed_id": userID
@@ -28,8 +28,8 @@ class Relationship {
         
         APIClient.request(endpoint: Endpoint.RelationshipDestroy, parameters: parameters) { response in
             switch response {
-            case .Success(let json):
-                handler()
+            case .Success:
+                handler(APIResponse.Success(nil))
             default: break
             }
             

--- a/Turmeric/Classes/Models/Relationship.swift
+++ b/Turmeric/Classes/Models/Relationship.swift
@@ -10,8 +10,12 @@ class Relationship {
             ]
         ]
         
-        APIClient.request(endpoint: Endpoint.RelationshipCreate, parameters: parameters) { json in
-            handler()
+        APIClient.request(endpoint: Endpoint.RelationshipCreate, parameters: parameters) { response in
+            switch response {
+            case .Success(let json):
+                handler()
+            default: break
+            }
         }
     }
     
@@ -22,8 +26,13 @@ class Relationship {
             ]
         ]
         
-        APIClient.request(endpoint: Endpoint.RelationshipDestroy, parameters: parameters) { json in
-            handler()
+        APIClient.request(endpoint: Endpoint.RelationshipDestroy, parameters: parameters) { response in
+            switch response {
+            case .Success(let json):
+                handler()
+            default: break
+            }
+            
         }
     }
 }

--- a/Turmeric/Classes/Models/User.swift
+++ b/Turmeric/Classes/Models/User.swift
@@ -34,23 +34,24 @@ class User {
         self.iconURL = URL(string: json["icon_url"].string!)!
     }
     
-    static func createUser(parameters: Parameters, handler: @escaping ((User) -> Void)) {
+    static func createUser(parameters: Parameters, handler: @escaping ((APIResponse<User>) -> Void)) {
         APIClient.request(endpoint: Endpoint.UsersCreate, parameters: parameters) { response in
             switch response {
             case .Success(let json):
-                handler(User(json: json["user"]))
+                handler(APIResponse.Success(User(json: json["user"])))
             default:
                 break
             }
         }
     }
 
-    static func getMyUser(handler: @escaping ((User) -> Void)) {
+
+    static func getMyUser(handler: @escaping ((APIResponse<User>) -> Void)) {
 
         APIClient.request(endpoint: Endpoint.UsersMe, parameters: [:]) { response in
             switch response {
             case .Success(let json):
-                handler(User(json: json["user"]))
+                handler(APIResponse.Success(User(json: json["user"])))
             default:
                 break
             }
@@ -58,72 +59,72 @@ class User {
         }
     }
     
-    static func getUser(userID: Int, handler: @escaping ((User) -> Void)){
+    static func getUser(userID: Int, handler: @escaping ((APIResponse<User>) -> Void)){
         APIClient.request(endpoint: Endpoint.UsersShow(userID)) { response in
             switch response {
-            case .Success(let user):
-                handler(User(json: json["user"]))
+            case .Success(let json):
+                handler(APIResponse.Success(User(json: json["user"])))
             default: break
             }
         }
     }
 
-    static func authenticate(parameters: Parameters, handler: @escaping (Any?) -> Void) {
+    static func authenticate(parameters: Parameters, handler: @escaping (APIResponse<Any?>) -> Void) {
         APIClient.request(endpoint: Endpoint.Auth, parameters: parameters) { response in
             switch response {
             case .Success(let json):
                 APIClient.token = json["token"].string!
-                handler(nil)
+                handler(APIResponse.Success(nil))
             default:
                 break
             }
         }
     }
 
-    static func getMyFeed(handler: @escaping ([Micropost]?) -> Void) {
+    static func getMyFeed(handler: @escaping (APIResponse<[Micropost]?>) -> Void) {
         APIClient.request(endpoint: Endpoint.MyFeed) { response in
             switch response {
             case .Success(let json):
                 let microposts: [Micropost]? = (json["feed"].array?.map {
                     Micropost(json: $0)
                     })
-                handler(microposts)
+                handler(APIResponse.Success(microposts))
             default: break
             }
         }
     }
 
-    static func getMyLists(handler: @escaping ([List]?) -> Void) {
+    static func getMyLists(handler: @escaping (APIResponse<[List]?>) -> Void) {
         APIClient.request(endpoint: Endpoint.MyLists) { response in
             switch response {
             case .Success(let json):
                 let lists: [List]? = (json["lists"].array?.map {
                     List(json: $0)
                     })
-                handler(lists)
+                handler(APIResponse.Success(lists))
             default:
                 break
             }
         }
     }
 
-    static func getFollowing(id: Int, handler: @escaping (([User]?) -> Void) ) {
+    static func getFollowing(id: Int, handler: @escaping ((APIResponse<[User]?>) -> Void) ) {
         APIClient.request(endpoint: Endpoint.UsersFollowing(id)) { response in
             switch response {
             case .Success(let json):
                 let users: [User]? = (json["following"]["users"].array?.map { User(json: $0) })
-                handler(users)
+                handler(APIResponse.Success(users))
             default: break
             }
         }
     }
 
-    static func getFollowers(id: Int, handler: @escaping (([User]?) -> Void) ) {
+    static func getFollowers(id: Int, handler: @escaping ((APIResponse<[User]?>) -> Void) ) {
         APIClient.request(endpoint: Endpoint.UsersFollowers(id)) { response in
             switch response {
             case .Success(let json):
                 let users: [User]? = (json["followers"]["users"].array?.map { User(json: $0) })
-                handler(users)
+                handler(APIResponse.Success(users))
             default: break
             }
         }

--- a/Turmeric/Classes/Models/User.swift
+++ b/Turmeric/Classes/Models/User.swift
@@ -35,59 +35,97 @@ class User {
     }
     
     static func createUser(parameters: Parameters, handler: @escaping ((User) -> Void)) {
-        APIClient.request(endpoint: Endpoint.UsersCreate, parameters: parameters) { json in
-            handler(User(json: json["user"]))
+        APIClient.request(endpoint: Endpoint.UsersCreate, parameters: parameters) { response in
+            switch response {
+            case .Success(let json):
+                handler(User(json: json["user"]))
+            default:
+                break
+            }
         }
     }
 
     static func getMyUser(handler: @escaping ((User) -> Void)) {
-        APIClient.request(endpoint: Endpoint.UsersMe) { json in
-            handler(User(json: json["user"]))
+
+        APIClient.request(endpoint: Endpoint.UsersMe, parameters: [:]) { response in
+            switch response {
+            case .Success(let json):
+                handler(User(json: json["user"]))
+            default:
+                break
+            }
+
         }
     }
     
     static func getUser(userID: Int, handler: @escaping ((User) -> Void)){
-        APIClient.request(endpoint: Endpoint.UsersShow(userID)) { json in
-            handler(User(json: json["user"]))
+        APIClient.request(endpoint: Endpoint.UsersShow(userID)) { response in
+            switch response {
+            case .Success(let user):
+                handler(User(json: json["user"]))
+            default: break
+            }
         }
     }
 
     static func authenticate(parameters: Parameters, handler: @escaping (Any?) -> Void) {
-        APIClient.request(endpoint: Endpoint.Auth, parameters: parameters) { json in
-            APIClient.token = json["token"].string!
-            handler(nil)
+        APIClient.request(endpoint: Endpoint.Auth, parameters: parameters) { response in
+            switch response {
+            case .Success(let json):
+                APIClient.token = json["token"].string!
+                handler(nil)
+            default:
+                break
+            }
         }
     }
 
     static func getMyFeed(handler: @escaping ([Micropost]?) -> Void) {
-        APIClient.request(endpoint: Endpoint.MyFeed) { json in
-            let microposts: [Micropost]? = (json["feed"].array?.map {
-                Micropost(json: $0)
-                })
-            handler(microposts)
+        APIClient.request(endpoint: Endpoint.MyFeed) { response in
+            switch response {
+            case .Success(let json):
+                let microposts: [Micropost]? = (json["feed"].array?.map {
+                    Micropost(json: $0)
+                    })
+                handler(microposts)
+            default: break
+            }
         }
     }
 
     static func getMyLists(handler: @escaping ([List]?) -> Void) {
-        APIClient.request(endpoint: Endpoint.MyLists) { json in
-            let lists: [List]? = (json["lists"].array?.map {
-                List(json: $0)
-                })
-            handler(lists)
+        APIClient.request(endpoint: Endpoint.MyLists) { response in
+            switch response {
+            case .Success(let json):
+                let lists: [List]? = (json["lists"].array?.map {
+                    List(json: $0)
+                    })
+                handler(lists)
+            default:
+                break
+            }
         }
     }
 
     static func getFollowing(id: Int, handler: @escaping (([User]?) -> Void) ) {
-        APIClient.request(endpoint: Endpoint.UsersFollowing(id)) { json in
-            let users: [User]? = (json["following"]["users"].array?.map { User(json: $0) })
-            handler(users)
+        APIClient.request(endpoint: Endpoint.UsersFollowing(id)) { response in
+            switch response {
+            case .Success(let json):
+                let users: [User]? = (json["following"]["users"].array?.map { User(json: $0) })
+                handler(users)
+            default: break
+            }
         }
     }
 
     static func getFollowers(id: Int, handler: @escaping (([User]?) -> Void) ) {
-        APIClient.request(endpoint: Endpoint.UsersFollowers(id)) { json in
-            let users: [User]? = (json["followers"]["users"].array?.map { User(json: $0) })
-            handler(users)
+        APIClient.request(endpoint: Endpoint.UsersFollowers(id)) { response in
+            switch response {
+            case .Success(let json):
+                let users: [User]? = (json["followers"]["users"].array?.map { User(json: $0) })
+                handler(users)
+            default: break
+            }
         }
     }
 }

--- a/Turmeric/Classes/Views/MembersFollow.swift
+++ b/Turmeric/Classes/Views/MembersFollow.swift
@@ -39,23 +39,29 @@ class MembersFollow: UITableViewCell {
         self.user = user
         
         // 自分のフォローリストにuserが含まれてるか判定してボタンを書き換える
-        User.getMyUser(){ me in
-            User.getFollowing(id: me.id){ following in
-                self.button.isHidden = false    // レスポンスが来たので隠すのをやめる
-                
-                self.isFollowedByMe = false
-                
-                var title = "フォロー"
-                
-                following?.forEach() { followedByMe in
-                    if(followedByMe.id == user.id){
-                        self.isFollowedByMe = true
-                        title = "アンフォロー"
-                        return
+        User.getMyUser(){ getMyUserResponse in
+            switch getMyUserResponse {
+            case .Success(let me):
+                User.getFollowing(id: me.id){ response in
+                    self.button.isHidden = false    // レスポンスが来たので隠すのをやめる
+                    
+                    self.isFollowedByMe = false
+                    
+                    var title = "フォロー"
+                    switch response {
+                    case .Success(let following):
+                        following?.forEach() { followedByMe in
+                            if(followedByMe.id == user.id){
+                                self.isFollowedByMe = true
+                                title = "アンフォロー"
+                                return
+                            }
+                        }
+                        self.button.setTitle(title, for: UIControlState.normal)
+                    default: break
                     }
                 }
-                
-                self.button.setTitle(title, for: UIControlState.normal)
+            default: break
             }
         }
     }
@@ -63,14 +69,24 @@ class MembersFollow: UITableViewCell {
     // フォロー/アンフォローボタン押下
     @IBAction func followButtonDidTap(_ sender: AnyObject) {
         if(self.isFollowedByMe!){
-            Relationship.destroyRelationship(userID: user.id){
-                self.isFollowedByMe = false
-                self.button.setTitle("フォロー", for: UIControlState.normal)
+            Relationship.destroyRelationship(userID: user.id){ response in
+                switch response {
+                case .Success:
+                    self.isFollowedByMe = false
+                    self.button.setTitle("フォロー", for: UIControlState.normal)
+                default: break
+                }
+                
             }
         }else{
-            Relationship.createRelationship(userID: user.id){
-                self.isFollowedByMe = true
-                self.button.setTitle("アンフォロー", for: UIControlState.normal)
+            Relationship.createRelationship(userID: user.id){ response in
+                switch response {
+                case .Success:
+                    self.isFollowedByMe = true
+                    self.button.setTitle("アンフォロー", for: UIControlState.normal)
+                default: break
+                }
+                
             }
         }
     }

--- a/TurmericTests/Models/ListTests.swift
+++ b/TurmericTests/Models/ListTests.swift
@@ -18,9 +18,13 @@ class ListTests: XCTestCase {
     func testListShow() {
         waitUntil { done in
             List.getList(id: 1) { response in
-                XCTAssertEqual(1, response.id)
-                XCTAssertEqual("Friends", response.name)
-                done()
+                switch response {
+                case .Success(let list):
+                    XCTAssertEqual(1, list.id)
+                    XCTAssertEqual("Friends", list.name)
+                    done()
+                default: break
+                }
             }
         }
     }
@@ -28,12 +32,16 @@ class ListTests: XCTestCase {
     func testListMembers() {
         waitUntil { done in
             List.getMembers(id: 1) { response in
-                response.forEach {
-                    XCTAssertNotNil($0.id)
-                    XCTAssertNotNil($0.name)
-                    XCTAssertNotNil($0.iconURL)
+                switch response {
+                case .Success(let members):
+                    members.forEach {
+                        XCTAssertNotNil($0.id)
+                        XCTAssertNotNil($0.name)
+                        XCTAssertNotNil($0.iconURL)
+                    }
+                    done()
+                default: break
                 }
-                done()
             }
         }
     }
@@ -42,33 +50,49 @@ class ListTests: XCTestCase {
         let parameters = ["list" : ["name" : "myFriends"]]
         waitUntil { done in
             List.update(id: 1, parameters: parameters) { response in
-                XCTAssertEqual(1, response.id)
-                XCTAssertEqual("myFriends", response.name)
-                done()
+                switch response {
+                case .Success(let list):
+                    XCTAssertEqual(1, list.id)
+                    XCTAssertEqual("myFriends", list.name)
+                    done()
+                default: break
+                }
             }
         }
     }
     
     func testDeleteMembers() {
         waitUntil { done in
-            List.deleteMember(listId: 1, memberId: 101) {
-                done()
+            List.deleteMember(listId: 1, memberId: 101) { response in
+                switch response {
+                case .Success:
+                    done()
+                default: break
+                }
             }
         }
     }
     
     func testAddMembers() {
         waitUntil { done in
-            List.addMember(id: 1, parameters: ["user_id" : 102]) {_ in
-                done()
+            List.addMember(id: 1, parameters: ["user_id" : 102]) { response in
+                switch response {
+                case .Success:
+                    done()
+                default: break
+                }
             }
         }
     }
     
     func testDeleteList() {
         waitUntil { done in
-            List.deleteList(id: 1) {_ in
-                done()
+            List.deleteList(id: 1) {response in
+                switch response {
+                case .Success:
+                    done()
+                default: break
+                }
             }
         }
     }
@@ -76,8 +100,12 @@ class ListTests: XCTestCase {
     func testListCreate() {
         waitUntil { done in
             List.createList(parameters: ["list" : ["name" : "engineer"]]) {response in
-                XCTAssertEqual(response.name, "engineer")
-                done()
+                switch response {
+                case .Success(let list):
+                    XCTAssertEqual(list.name, "engineer")
+                    done()
+                default: break
+                }
             }
         }
     }

--- a/TurmericTests/Models/MicropostTests.swift
+++ b/TurmericTests/Models/MicropostTests.swift
@@ -21,9 +21,13 @@ class MicropostTests: XCTestCase {
         
         waitUntil { done in
             Micropost.postMicropost(parameters: parameters){ response in
-                XCTAssertEqual("I just ate an orange!", response.content)
-                XCTAssertEqual("Example User", response.user.name)
-                done()
+                switch response {
+                case .Success(let micropost):
+                    XCTAssertEqual("I just ate an orange!", micropost.content)
+                    XCTAssertEqual("Example User", micropost.user.name)
+                    done()
+                default: break
+                }
             }
         }
     }
@@ -31,23 +35,30 @@ class MicropostTests: XCTestCase {
     func testGetMicropost() {
         waitUntil { done in
             Micropost.getMicropost(id: 100) { response in
-                XCTAssertEqual(100, response.id)
-                XCTAssertEqual(1, response.userId)
-                XCTAssertEqual("I just ate an orange!", response.content)
-                XCTAssertNil(response.picture)
-                // マイクロポストにユーザー情報が含まれているかテスト
-                XCTAssertEqual("Example User", response.user.name)
-                done()
+                switch response {
+                case .Success(let micropost):
+                    XCTAssertEqual(100, micropost.id)
+                    XCTAssertEqual(1, micropost.userId)
+                    XCTAssertEqual("I just ate an orange!", micropost.content)
+                    XCTAssertNil(micropost.picture)
+                    XCTAssertEqual("Example User", micropost.user.name)
+                    done()
+                default: break
+                }
             }
         }
         waitUntil { done in
             Micropost.getMicropost(id: 101) { response in
-                XCTAssertEqual(101, response.id)
-                XCTAssertEqual(2, response.userId)
-                XCTAssertEqual("With picture", response.content)
-                XCTAssertEqual("https://example.com/picture.jpg", response.picture?.absoluteString)
-                XCTAssertEqual("Michael", response.user.name)
-                done()
+                switch response {
+                case .Success(let micropost):
+                    XCTAssertEqual(101, micropost.id)
+                    XCTAssertEqual(2, micropost.userId)
+                    XCTAssertEqual("With picture", micropost.content)
+                    XCTAssertEqual("https://example.com/picture.jpg", micropost.picture?.absoluteString)
+                    XCTAssertEqual("Michael", micropost.user.name)
+                    done()
+                default: break
+                }
             }
         }
     }

--- a/TurmericTests/Models/RelationshipTests.swift
+++ b/TurmericTests/Models/RelationshipTests.swift
@@ -21,8 +21,12 @@ class RelationshipTests: XCTestCase {
         login()
         
         waitUntil { done in
-            Relationship.createRelationship(userID: 102){
-                done()
+            Relationship.createRelationship(userID: 102){ response in
+                switch response {
+                case .Success:
+                    done()
+                default: break
+                }
             }
         }
     }
@@ -31,8 +35,12 @@ class RelationshipTests: XCTestCase {
         login()
         
         waitUntil { done in
-            Relationship.destroyRelationship(userID: 101){
-                done()
+            Relationship.destroyRelationship(userID: 101){ response in
+                switch response {
+                case .Success:
+                    done()
+                default: break
+                }
             }
         }
     }

--- a/TurmericTests/Models/UserTests.swift
+++ b/TurmericTests/Models/UserTests.swift
@@ -31,8 +31,12 @@ class UserTests: XCTestCase {
         // リクエスト処理を同期的に実行する
         waitUntil { done in
             User.createUser(parameters: parameters){ response in
-                XCTAssertEqual("Example User", response.name)
-                done()
+                switch response {
+                case .Success(let user):
+                    XCTAssertEqual("Example User", user.name)
+                    done()
+                default: break
+                }
             }
         }
     }
@@ -40,12 +44,17 @@ class UserTests: XCTestCase {
     func testUserMe() {
         waitUntil { done in
             User.getMyUser(){ response in
-                XCTAssertEqual("Example User", response.name)
-                XCTAssertEqual(100, response.followingCount)
-                XCTAssertEqual(200, response.followersCount)
-                XCTAssertEqual(1000, response.micropostsCount)
-                XCTAssertEqual("https://secure.gravatar.com/avatar/b58996c504c5638798eb6b511e6f49af?s=80", response.iconURL.absoluteString)
-                done()
+                switch response {
+                case .Success(let user):
+                    XCTAssertEqual("Example User", user.name)
+                    XCTAssertEqual(100, user.followingCount)
+                    XCTAssertEqual(200, user.followersCount)
+                    XCTAssertEqual(1000, user.micropostsCount)
+                    XCTAssertEqual("https://secure.gravatar.com/avatar/b58996c504c5638798eb6b511e6f49af?s=80", user.iconURL.absoluteString)
+                    done()
+                default: break
+                }
+                
             }
         }
     }
@@ -53,8 +62,12 @@ class UserTests: XCTestCase {
     func testUserLogin() {
         waitUntil { done in
             User.authenticate(parameters: ["user": ["email": "test@example.com", "password": "F0oB@rbaz"]]) { response in
-                XCTAssertEqual("This.Is.Example-Auth-Token", APIClient.token)
-                done()
+                switch response {
+                case .Success:
+                    XCTAssertEqual("This.Is.Example-Auth-Token", APIClient.token)
+                    done()
+                default: break
+                }
             }
         }
     }
@@ -63,13 +76,17 @@ class UserTests: XCTestCase {
         login()
         waitUntil { done in
             User.getMyFeed { response in
-                response!.forEach {
-                    XCTAssertNotNil($0.id)
-                    XCTAssertNotNil($0.content)
-                    XCTAssertNotNil($0.userId)
-                    XCTAssertNotNil($0.user.name)
+                switch response {
+                case .Success(let feed):
+                    feed!.forEach {
+                        XCTAssertNotNil($0.id)
+                        XCTAssertNotNil($0.content)
+                        XCTAssertNotNil($0.userId)
+                        XCTAssertNotNil($0.user.name)
+                    }
+                    done()
+                default: break
                 }
-                done()
             }
         }
     }
@@ -79,11 +96,15 @@ class UserTests: XCTestCase {
 
         waitUntil { done in
             User.getMyLists { response in
-                response!.forEach {
-                    XCTAssertNotNil($0.id)
-                    XCTAssertNotNil($0.name)
+                switch response {
+                case .Success(let lists):
+                    lists!.forEach {
+                        XCTAssertNotNil($0.id)
+                        XCTAssertNotNil($0.name)
+                    }
+                    done()
+                default: break
                 }
-                done()
             }
         }
     }
@@ -93,11 +114,15 @@ class UserTests: XCTestCase {
 
         waitUntil { done in
             User.getFollowing(id: 1) { response in
-                response!.forEach {
-                    XCTAssertNotNil($0.id)
-                    XCTAssertNotNil($0.name)
+                switch response {
+                case .Success(let following):
+                    following!.forEach {
+                        XCTAssertNotNil($0.id)
+                        XCTAssertNotNil($0.name)
+                    }
+                    done()
+                default: break
                 }
-                done()
             }
         }
     }
@@ -107,11 +132,15 @@ class UserTests: XCTestCase {
 
         waitUntil { done in
             User.getFollowers(id: 1) { response in
-                response!.forEach {
-                    XCTAssertNotNil($0.id)
-                    XCTAssertNotNil($0.name)
+                switch response {
+                case .Success(let followers):
+                    followers!.forEach {
+                        XCTAssertNotNil($0.id)
+                        XCTAssertNotNil($0.name)
+                    }
+                    done()
+                default: break
                 }
-                done()
             }
         }
     }


### PR DESCRIPTION
現状では、APIクライアントで何かしらのエラーが発生した場合、標準出力して終わっています。
エラーが発生しても適切に処理できるようにまず、APIクライアント側でエラーハンドリングができるようにします
