### PR TITLE
フォローフォロワー一覧読み込み問題の修正

### DIFF
--- a/Turmeric/Classes/Controllers/OthersProfileViewController.swift
+++ b/Turmeric/Classes/Controllers/OthersProfileViewController.swift
@@ -78,17 +78,13 @@ class OthersProfileViewController: UIViewController {
             let vc = segue.destination as! UsersViewController
             
             // 次のvcにフォローユーザたちを表示するように依頼
-            User.getFollowing(id: user!.id){ following in
-                vc.displayUsers = following!
-            }
+            vc.displayStyle = UsersViewController.DisplayStyle.Following(user!.id)
             break
         case "followers":
             let vc = segue.destination as! UsersViewController
             
             // 次のvcにフォロワーたちを表示するように依頼
-            User.getFollowers(id: user!.id){ followers in
-                vc.displayUsers = followers!
-            }
+            vc.displayStyle = UsersViewController.DisplayStyle.Followers(user!.id)
             break
         default:
             break

--- a/Turmeric/Classes/Controllers/ProfileViewController.swift
+++ b/Turmeric/Classes/Controllers/ProfileViewController.swift
@@ -16,11 +16,15 @@ class ProfileViewController: UIViewController {
     @IBOutlet weak var followingButton: UIButton!
     @IBOutlet weak var profileImage: UIImageView!
 
+    var me: User? = nil
+    
     //var followingButton: UIButton
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
         User.getMyUser(){ user in
+            self.me = user
+            
             self.usernameLabel.text = user.name
 
             if let micropostCount = user.micropostsCount, let followersCount = user.followersCount, let followingCount = user.followingCount {
@@ -51,23 +55,11 @@ class ProfileViewController: UIViewController {
         switch(segueID){
         case "following":
             let vc = segue.destination as! UsersViewController
-
-            // 次のvcに自分のフォローユーザたちを表示するように依頼
-            User.getMyUser(){ me in
-                User.getFollowing(id: me.id){ following in
-                    vc.displayUsers = following!
-                }
-            }
+            vc.displayStyle = UsersViewController.DisplayStyle.Following(me!.id)
             break
         case "followers":
             let vc = segue.destination as! UsersViewController
-
-            // 次のvcに自分のフォロワーたちを表示するように依頼
-            User.getMyUser(){ me in
-                User.getFollowers(id: me.id){ followers in
-                    vc.displayUsers = followers!
-                }
-            }
+            vc.displayStyle = UsersViewController.DisplayStyle.Followers(me!.id)
             break
         default:
             break

--- a/Turmeric/Classes/Controllers/UsersViewController.swift
+++ b/Turmeric/Classes/Controllers/UsersViewController.swift
@@ -10,6 +10,13 @@ import UIKit
 
 class UsersViewController: UITableViewController {
 
+    enum DisplayStyle {
+        case Following(Int)
+        case Followers(Int)
+    }
+    
+    var displayStyle: DisplayStyle? = nil
+    
     // 遷移元のVCで、このプロパティに表示したいユーザをsetする
     var displayUsers: [User] {
         get { return self.displayUsersVal }
@@ -26,6 +33,23 @@ class UsersViewController: UITableViewController {
         tableView.register(UINib(nibName: "MembersFollow", bundle: nil), forCellReuseIdentifier: "membersFollow")
 
         super.viewDidLoad()
+        
+        if self.displayStyle != nil {
+            switch self.displayStyle! {
+            case let UsersViewController.DisplayStyle.Following(userID):
+                User.getUser(userID: userID){ user in
+                    User.getFollowing(id: user.id){ following in
+                        self.displayUsers = following!
+                    }
+                }
+            case let UsersViewController.DisplayStyle.Followers(userID):
+                User.getUser(userID: userID){ user in
+                    User.getFollowers(id: user.id){ followers in
+                        self.displayUsers = followers!
+                    }
+                }
+            }
+        }
     }
     
     // tableの要素数

--- a/Turmeric/Classes/Controllers/UsersViewController.swift
+++ b/Turmeric/Classes/Controllers/UsersViewController.swift
@@ -36,18 +36,14 @@ class UsersViewController: UITableViewController {
         // フォロー一覧かフォロワー一覧かで読み込む内容を判別
         switch self.displayStyle! {
         case let UsersViewController.DisplayStyle.Following(userID):
-            User.getUser(userID: userID){ user in
-                User.getFollowing(id: user.id){ following in
-                    self.displayUsers = following!
-                    self.tableView.reloadData()
-                }
+            User.getFollowing(id: userID){ following in
+                self.displayUsers = following!
+                self.tableView.reloadData()
             }
         case let UsersViewController.DisplayStyle.Followers(userID):
-            User.getUser(userID: userID){ user in
-                User.getFollowers(id: user.id){ followers in
-                    self.displayUsers = followers!
-                    self.tableView.reloadData()
-                }
+            User.getFollowers(id: userID){ followers in
+                self.displayUsers = followers!
+                self.tableView.reloadData()
             }
         }
     }

--- a/Turmeric/Classes/Controllers/UsersViewController.swift
+++ b/Turmeric/Classes/Controllers/UsersViewController.swift
@@ -30,11 +30,11 @@ class UsersViewController: UITableViewController {
     
     var selectedUser: User!
     
-    override func viewDidLoad() {
+    override func viewWillAppear(_ animated: Bool) {
         // MembersFollow.xib のカスタムビューを基準としてテーブルビューに配置する
         tableView.register(UINib(nibName: "MembersFollow", bundle: nil), forCellReuseIdentifier: "membersFollow")
 
-        super.viewDidLoad()
+        super.viewWillAppear(animated)
         
         if self.displayStyle != nil {
             switch self.displayStyle! {

--- a/Turmeric/Classes/Controllers/UsersViewController.swift
+++ b/Turmeric/Classes/Controllers/UsersViewController.swift
@@ -15,20 +15,13 @@ class UsersViewController: UITableViewController {
         case Followers(Int)
     }
     
+    //遷移前にフォロー一覧かフォロワー一覧か指定
     var displayStyle: DisplayStyle? = nil
     
-    // 遷移元のVCで、このプロパティに表示したいユーザをsetする
-    var displayUsers: [User] {
-        get { return self.displayUsersVal }
-        
-        set {
-            self.displayUsersVal = newValue
-            self.tableView.reloadData()      // 非同期読み込みなどする場合があるのでsetされたら再描画
-        }
-    }
-    private var displayUsersVal: [User] = [] // displayUsersの実データ部
+    var displayUsers: [User] = []
     
-    var selectedUser: User!
+    // テーブルタップ時に選択したユーザをprepareまで保存
+    private var selectedUser: User!
     
     override func viewWillAppear(_ animated: Bool) {
         // MembersFollow.xib のカスタムビューを基準としてテーブルビューに配置する
@@ -36,18 +29,21 @@ class UsersViewController: UITableViewController {
 
         super.viewWillAppear(animated)
         
+        // フォロー一覧かフォロワー一覧かで読み込む内容を判別
         if self.displayStyle != nil {
             switch self.displayStyle! {
             case let UsersViewController.DisplayStyle.Following(userID):
                 User.getUser(userID: userID){ user in
                     User.getFollowing(id: user.id){ following in
                         self.displayUsers = following!
+                        self.tableView.reloadData()
                     }
                 }
             case let UsersViewController.DisplayStyle.Followers(userID):
                 User.getUser(userID: userID){ user in
                     User.getFollowers(id: user.id){ followers in
                         self.displayUsers = followers!
+                        self.tableView.reloadData()
                     }
                 }
             }
@@ -78,6 +74,7 @@ class UsersViewController: UITableViewController {
         if(segue.identifier == "profile"){
             let vc = segue.destination as! OthersProfileViewController
             
+            // 選択したユーザのプロフィールを表示するように次のVCに依頼
             vc.user = self.selectedUser
         }
     }

--- a/Turmeric/Classes/Controllers/UsersViewController.swift
+++ b/Turmeric/Classes/Controllers/UsersViewController.swift
@@ -29,22 +29,24 @@ class UsersViewController: UITableViewController {
 
         super.viewWillAppear(animated)
         
+        guard self.displayStyle != nil else {
+            return
+        }
+        
         // フォロー一覧かフォロワー一覧かで読み込む内容を判別
-        if self.displayStyle != nil {
-            switch self.displayStyle! {
-            case let UsersViewController.DisplayStyle.Following(userID):
-                User.getUser(userID: userID){ user in
-                    User.getFollowing(id: user.id){ following in
-                        self.displayUsers = following!
-                        self.tableView.reloadData()
-                    }
+        switch self.displayStyle! {
+        case let UsersViewController.DisplayStyle.Following(userID):
+            User.getUser(userID: userID){ user in
+                User.getFollowing(id: user.id){ following in
+                    self.displayUsers = following!
+                    self.tableView.reloadData()
                 }
-            case let UsersViewController.DisplayStyle.Followers(userID):
-                User.getUser(userID: userID){ user in
-                    User.getFollowers(id: user.id){ followers in
-                        self.displayUsers = followers!
-                        self.tableView.reloadData()
-                    }
+            }
+        case let UsersViewController.DisplayStyle.Followers(userID):
+            User.getUser(userID: userID){ user in
+                User.getFollowers(id: user.id){ followers in
+                    self.displayUsers = followers!
+                    self.tableView.reloadData()
                 }
             }
         }

--- a/Turmeric/Classes/Models/User.swift
+++ b/Turmeric/Classes/Models/User.swift
@@ -45,6 +45,12 @@ class User {
             handler(User(json: json["user"]))
         }
     }
+    
+    static func getUser(userID: Int, handler: @escaping ((User) -> Void)){
+        APIClient.request(endpoint: Endpoint.UsersShow(userID), parameters: [:]) { json in
+            handler(User(json: json["user"]))
+        }
+    }
 
     static func authenticate(parameters: Parameters, handler: @escaping (Any?) -> Void) {
         APIClient.request(endpoint: Endpoint.Auth, parameters: parameters) { json in

--- a/Turmeric/Classes/Models/User.swift
+++ b/Turmeric/Classes/Models/User.swift
@@ -41,13 +41,13 @@ class User {
     }
 
     static func getMyUser(handler: @escaping ((User) -> Void)) {
-        APIClient.request(endpoint: Endpoint.UsersMe, parameters: [:]) { json in
+        APIClient.request(endpoint: Endpoint.UsersMe) { json in
             handler(User(json: json["user"]))
         }
     }
     
     static func getUser(userID: Int, handler: @escaping ((User) -> Void)){
-        APIClient.request(endpoint: Endpoint.UsersShow(userID), parameters: [:]) { json in
+        APIClient.request(endpoint: Endpoint.UsersShow(userID)) { json in
             handler(User(json: json["user"]))
         }
     }


### PR DESCRIPTION
#57 #62 でフォローフォロワー一覧を作ったのですが、
#64 で触れたようにナビゲーションの帰り道で更新されない問題が生じました。

この問題の修正をします
### やったこと
- UserモデルにgetUserメソッドを追加
- UsersVCへの情報の渡し方の修正
  - enum型で定義
  - ProfileVC, OthersProfileVCの遷移前の修正
- ProfileVCで自分自身のことを記憶しておく記述を追記
  - prepareでもう一度自分の情報を取得するのを防ぐため
- UsersVCのViewWillAppearでユーザ一覧情報を読み込むように修正

プロフィール→フォロー一覧→フォローユーザのプロフィール→アンフォロー→unwind
という操作をすると、フォロー一覧からアンフォローしたユーザが消えていることが確認できると思います。
