### PR TITLE
ホームタブに切り替えた際、最新リストを常に読み込む

### DIFF
--- a/Turmeric/Classes/Controllers/HomeViewController.swift
+++ b/Turmeric/Classes/Controllers/HomeViewController.swift
@@ -5,6 +5,7 @@ class HomeViewController: ButtonBarPagerTabStripViewController {
     var lists: [List] = []
 
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         // AppDelegateからログイン完了の通知を受けたらリストを取得する
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
         appDelegate.loginDispatch.notify(queue: DispatchQueue.main, execute: {

--- a/Turmeric/Classes/Controllers/HomeViewController.swift
+++ b/Turmeric/Classes/Controllers/HomeViewController.swift
@@ -4,6 +4,17 @@ import XLPagerTabStrip
 class HomeViewController: ButtonBarPagerTabStripViewController {
     var lists: [List] = []
 
+    override func viewWillAppear(_ animated: Bool) {
+        // AppDelegateからログイン完了の通知を受けたらリストを取得する
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        appDelegate.loginDispatch.notify(queue: DispatchQueue.main, execute: {
+            User.getMyLists() { lists in
+                self.lists = lists!
+                self.reloadPagerTabStripView()
+            }
+        })
+    }
+    
     override func viewDidLoad() {
         // タブのデザイン
         settings.style.buttonBarBackgroundColor = .white
@@ -22,15 +33,6 @@ class HomeViewController: ButtonBarPagerTabStripViewController {
         // buttonBarViewはスーパークラスで定義されている
         buttonBarView.removeFromSuperview()
         navigationController?.navigationBar.addSubview(buttonBarView)
-
-        // AppDelegateからログイン完了の通知を受けたらリストを取得する
-        let appDelegate = UIApplication.shared.delegate as! AppDelegate
-        appDelegate.loginDispatch.notify(queue: DispatchQueue.main, execute: {
-            User.getMyLists() { lists in
-                self.lists = lists!
-                self.reloadPagerTabStripView()
-            }
-        })
     }
 
     override func didReceiveMemoryWarning() {


### PR DESCRIPTION
現在HomeViewControllerを開いた際、リストの読み込みもviewDidLoadでやっているため、ライフサイクルの関係でタブ切り替えではリストの読み込みがされません。
タブを切り替えた際常に最新リストを読み込むため、記述をviewWillAppearに移します
