### PR TITLE
ホームのfeedがタブやタブバーにめり込んでいるのでマージンを取る

### DIFF
--- a/Turmeric/Classes/Controllers/FeedViewController.swift
+++ b/Turmeric/Classes/Controllers/FeedViewController.swift
@@ -56,18 +56,10 @@ class FeedViewController: UITableViewController, IndicatorInfoProvider {
     
     
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        if(isHome){
-            return 20 // タブ分ずらす
-        }else{
-            return 0
-        }
+        return isHome ? 20 : 0
     }
     
     override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        if(isHome){
-            return 49 // タブバー分ずらす
-        }else{
-            return 0
-        }
+        return isHome ? 49 : 0
     }
 }

--- a/Turmeric/Classes/Controllers/FeedViewController.swift
+++ b/Turmeric/Classes/Controllers/FeedViewController.swift
@@ -4,6 +4,8 @@ import XLPagerTabStrip
 class FeedViewController: UITableViewController, IndicatorInfoProvider {
     var itemInfo = IndicatorInfo(title: "Feed")
     var microposts = [Micropost]()
+    
+    var isHome: Bool = false
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
@@ -50,5 +52,22 @@ class FeedViewController: UITableViewController, IndicatorInfoProvider {
         cell.profileImage.af_setImage(withURL: micropost.user.iconURL)
 
         return cell
+    }
+    
+    
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        if(isHome){
+            return 20 // タブ分ずらす
+        }else{
+            return 0
+        }
+    }
+    
+    override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        if(isHome){
+            return 49 // タブバー分ずらす
+        }else{
+            return 0
+        }
     }
 }

--- a/Turmeric/Classes/Controllers/HomeViewController.swift
+++ b/Turmeric/Classes/Controllers/HomeViewController.swift
@@ -59,6 +59,7 @@ class HomeViewController: ButtonBarPagerTabStripViewController {
         let storyboard = UIStoryboard(name: "Feed", bundle: nil)
         let feed = storyboard.instantiateInitialViewController() as! FeedViewController
         feed.itemInfo = IndicatorInfo(title: title)
+        feed.isHome = true
         return feed
     }
 }


### PR DESCRIPTION
feedがめり込んで表示されていたので、フッターヘッターとしてマージンを与えてやることで相殺しました。
後にこの方針に問題が出てくるようなら改めて考えたいです
![margin](https://cloud.githubusercontent.com/assets/11782371/19302209/2d7d3388-909e-11e6-834f-a357c51e3ec6.png)
