### PR TITLE
Feed からプロフィールページに飛ぶ

### DIFF
--- a/Turmeric.xcodeproj/project.pbxproj
+++ b/Turmeric.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		724DB9151D99271B00008C25 /* Post.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9141D99271B00008C25 /* Post.storyboard */; };
 		724DB9171D99274A00008C25 /* Profile.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9161D99274A00008C25 /* Profile.storyboard */; };
 		724DB9191D99275300008C25 /* Lists.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724DB9181D99275300008C25 /* Lists.storyboard */; };
+		7257DD0D1DAE3B9700D8B00D /* PerformSegueToProfileDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7257DD0C1DAE3B9700D8B00D /* PerformSegueToProfileDelegate.swift */; };
 		725B13131DA2450C00A12006 /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725B13121DA2450C00A12006 /* Stub.swift */; };
 		725B13181DA35C4600A12006 /* Me.json in Resources */ = {isa = PBXBuildFile; fileRef = 725B13171DA35C4600A12006 /* Me.json */; };
 		725B131A1DA39AFC00A12006 /* PostKeyboardToolbar.xib in Resources */ = {isa = PBXBuildFile; fileRef = 725B13191DA39AFC00A12006 /* PostKeyboardToolbar.xib */; };
@@ -198,6 +199,7 @@
 		724DB9141D99271B00008C25 /* Post.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Post.storyboard; sourceTree = "<group>"; };
 		724DB9161D99274A00008C25 /* Profile.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Profile.storyboard; sourceTree = "<group>"; };
 		724DB9181D99275300008C25 /* Lists.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Lists.storyboard; sourceTree = "<group>"; };
+		7257DD0C1DAE3B9700D8B00D /* PerformSegueToProfileDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformSegueToProfileDelegate.swift; sourceTree = "<group>"; };
 		725B13121DA2450C00A12006 /* Stub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stub.swift; sourceTree = "<group>"; };
 		725B13171DA35C4600A12006 /* Me.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Me.json; sourceTree = "<group>"; };
 		725B13191DA39AFC00A12006 /* PostKeyboardToolbar.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PostKeyboardToolbar.xib; sourceTree = "<group>"; };
@@ -324,6 +326,7 @@
 				72B150251DAC8A8B005E7523 /* OthersProfileViewController.swift */,
 				526437171DAC9B3C0034F7F2 /* ListCreateViewController.swift */,
 				5264371B1DACB8F80034F7F2 /* ListFormViewController.swift */,
+				7257DD0C1DAE3B9700D8B00D /* PerformSegueToProfileDelegate.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -724,6 +727,7 @@
 				522C8AA71D9CBC2C00E17D4C /* List.swift in Sources */,
 				52685A271D990E4400FEC0A7 /* APIClient.swift in Sources */,
 				52A44A7B1D9E304500DE76FD /* ListViewController.swift in Sources */,
+				7257DD0D1DAE3B9700D8B00D /* PerformSegueToProfileDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Turmeric/Classes/Controllers/FeedViewController.swift
+++ b/Turmeric/Classes/Controllers/FeedViewController.swift
@@ -58,6 +58,11 @@ class FeedViewController: UITableViewController, IndicatorInfoProvider {
         return cell
     }
     
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        var selectedUser = self.microposts[indexPath.row].user
+        self.parent?.performSegue(withIdentifier: "profile", sender: nil)
+    }
+    
     
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return isHome ? 20 : 0

--- a/Turmeric/Classes/Controllers/FeedViewController.swift
+++ b/Turmeric/Classes/Controllers/FeedViewController.swift
@@ -59,8 +59,10 @@ class FeedViewController: UITableViewController, IndicatorInfoProvider {
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        var selectedUser = self.microposts[indexPath.row].user
-        self.parent?.performSegue(withIdentifier: "profile", sender: nil)
+        let selectedUser = self.microposts[indexPath.row].user
+        let parent = self.parent as! PerformSegueToProfileDelegate
+        
+        parent.performSegueToProfile(user: selectedUser)
     }
     
     

--- a/Turmeric/Classes/Controllers/HomeViewController.swift
+++ b/Turmeric/Classes/Controllers/HomeViewController.swift
@@ -1,9 +1,11 @@
 import UIKit
 import XLPagerTabStrip
 
-class HomeViewController: ButtonBarPagerTabStripViewController {
+class HomeViewController: ButtonBarPagerTabStripViewController, PerformSegueToProfileDelegate {
     var lists: [List] = []
 
+    var selectedUser: User! = nil;
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         // AppDelegateからログイン完了の通知を受けたらリストを取得する
@@ -84,6 +86,14 @@ class HomeViewController: ButtonBarPagerTabStripViewController {
             for subview in subviews! {
                 subview.isHidden = true
             }
+            
+            let vc = segue.destination as! OthersProfileViewController
+            vc.user = self.selectedUser
         }
+    }
+    
+    func performSegueToProfile(user: User) {
+        self.selectedUser = user
+        performSegue(withIdentifier: "profile", sender: self)
     }
 }

--- a/Turmeric/Classes/Controllers/HomeViewController.swift
+++ b/Turmeric/Classes/Controllers/HomeViewController.swift
@@ -20,6 +20,16 @@ class HomeViewController: ButtonBarPagerTabStripViewController {
         })
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        // ナビから戻ってきたらタブを復活させる
+        let subviews = navigationController?.navigationBar.subviews
+        for subview in subviews! {
+            subview.isHidden = false
+        }
+    }
+    
     override func viewDidLoad() {
         // タブのデザイン
         settings.style.buttonBarBackgroundColor = .white
@@ -65,5 +75,15 @@ class HomeViewController: ButtonBarPagerTabStripViewController {
         feed.itemInfo = IndicatorInfo(title: title)
         feed.isHome = true
         return feed
+    }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if(segue.identifier == "profile"){
+            // navbarをナビに使うのでタブを退場させる
+            let subviews = navigationController?.navigationBar.subviews
+            for subview in subviews! {
+                subview.isHidden = true
+            }
+        }
     }
 }

--- a/Turmeric/Classes/Controllers/OthersProfileViewController.swift
+++ b/Turmeric/Classes/Controllers/OthersProfileViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class OthersProfileViewController: UIViewController {
+class OthersProfileViewController: UIViewController, PerformSegueToProfileDelegate {
     @IBOutlet weak var followButton: LinedButton!
     @IBOutlet weak var followingButton: UIButton!
     @IBOutlet weak var followersButton: UIButton!
@@ -125,6 +125,11 @@ class OthersProfileViewController: UIViewController {
             }
         }
 
+    }
+    
+    func performSegueToProfile(user: User) {
+        //プロフィールからプロフィールに遷移しても仕方ないので遷移しない
+        return
     }
 
 }

--- a/Turmeric/Classes/Controllers/PerformSegueToProfileDelegate.swift
+++ b/Turmeric/Classes/Controllers/PerformSegueToProfileDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  PerformToProfileDelegate.swift
+//  Turmeric
+//
+//  Created by usr0600437 on 2016/10/12.
+//  Copyright © 2016年 GMO Pepabo. All rights reserved.
+//
+
+import Foundation
+
+protocol PerformSegueToProfileDelegate {
+    func performSegueToProfile(user: User)
+}

--- a/Turmeric/Classes/Controllers/ProfileViewController.swift
+++ b/Turmeric/Classes/Controllers/ProfileViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class ProfileViewController: UIViewController {
+class ProfileViewController: UIViewController, PerformSegueToProfileDelegate {
 
     @IBOutlet weak var usernameLabel: UILabel!
     @IBOutlet weak var micropostsLabel: UILabel!
@@ -69,5 +69,10 @@ class ProfileViewController: UIViewController {
         default:
             break
         }
+    }
+    
+    func performSegueToProfile(user: User) {
+        //プロフィールからプロフィールに遷移しても仕方ないので遷移しない
+        return
     }
 }

--- a/Turmeric/Storyboards/Home.storyboard
+++ b/Turmeric/Storyboards/Home.storyboard
@@ -32,10 +32,23 @@
                     </view>
                     <navigationItem key="navigationItem" id="X1m-Hy-NKb"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <segue destination="w7v-H3-5Xq" kind="push" identifier="profile" id="h4m-3X-dXZ"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="QBn-TM-mdx" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1007.2" y="-124.58770614692655"/>
+        </scene>
+        <!--OthersProfile-->
+        <scene sceneID="BOJ-2B-Qr6">
+            <objects>
+                <viewControllerPlaceholder storyboardName="OthersProfile" id="w7v-H3-5Xq" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="oIy-3x-1Xg"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="AY8-Nd-EGy" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1806" y="-125"/>
         </scene>
         <!--ホーム-->
         <scene sceneID="WoB-5h-xwJ">

--- a/TurmericUITests/FeedUITests.swift
+++ b/TurmericUITests/FeedUITests.swift
@@ -61,4 +61,15 @@ class FeedUITests: XCTestCase {
         XCTAssert(lastCell.staticTexts["Profile Test User"].exists)
         XCTAssert(lastCell.staticTexts["投稿1"].exists)
     }
+    
+    func testPerformSegueToProfile() {
+        let app = XCUIApplication()
+        let micropostCells = app.tables.cells
+        
+        // 最初のセル
+        let firstCell = micropostCells.element(boundBy: 0)
+        firstCell.staticTexts["Example User"].tap()
+        XCTAssert(app.staticTexts["プロフィール"].exists) // プロフ画面タイトル
+        
+    }
 }


### PR DESCRIPTION
feedのmicropostをタップしたらプロフィールに飛ぶようにしました

タブがnavbarを独占したがるので、プロフィール遷移時に全部隠しています。
戻ってきたら再表示します
