### PR TITLE
APIサーバがエラーを返してきたら、そのままコントローラに渡す

### DIFF
--- a/Turmeric/Classes/Helpers/APIClient.swift
+++ b/Turmeric/Classes/Helpers/APIClient.swift
@@ -155,4 +155,13 @@ enum APIResponse<ResultType> {
     case ValidationError(JSON) //バリデーションエラー
     case Unauthorized          //認証エラー
     case RequestFailure        //その他のエラー
+    
+    //エラーは型を変換して返す
+    func error<T>(type: T.Type) -> APIResponse<T> {
+        switch self {
+        case .ValidationError(let json): return APIResponse<T>.ValidationError(json)
+        case .Unauthorized: return APIResponse<T>.Unauthorized
+        default: return APIResponse<T>.RequestFailure
+        }
+    }
 }

--- a/Turmeric/Classes/Models/List.swift
+++ b/Turmeric/Classes/Models/List.swift
@@ -21,7 +21,9 @@ class List {
             switch response {
             case .Success(let json):
                 handler(APIResponse.Success(List(json: json["list"])))
-            default: break
+            default:
+                let error = response.error(type: List.self)
+                handler(error)
             }
             
         }
@@ -35,7 +37,9 @@ class List {
                     User(json: $0)
                 }
                 handler(APIResponse.Success(members))
-            default: break
+            default:
+                let error = response.error(type: [User].self)
+                handler(error)
             }
             
         }
@@ -46,7 +50,9 @@ class List {
             switch response {
             case .Success(let json):
                 handler(APIResponse.Success(List(json: json["list"])))
-            default: break
+            default:
+                let error = response.error(type: List.self)
+                handler(error)
             }
             
         }
@@ -57,7 +63,9 @@ class List {
             switch response {
             case .Success:
                 handler(APIResponse.Success(nil))
-            default: break
+            default:
+                let error = response.error(type: (Any?.self)!)
+                handler(error)
             }
             
         }
@@ -68,7 +76,9 @@ class List {
             switch response {
             case .Success:
                 handler(APIResponse.Success(nil))
-            default: break
+            default:
+                let error = response.error(type: (Any?.self)!)
+                handler(error)
             }
         }
     }
@@ -78,7 +88,9 @@ class List {
             switch response {
             case .Success:
                 handler(APIResponse.Success(nil))
-            default: break
+            default:
+                let error = response.error(type: (Any?.self)!)
+                handler(error)
             }
         }
     }
@@ -88,7 +100,9 @@ class List {
             switch response {
             case .Success(let json):
                 handler(APIResponse.Success(List(json: json["list"])))
-            default: break
+            default:
+                let error = response.error(type: List.self)
+                handler(error)
             }
         }
     }

--- a/Turmeric/Classes/Models/Micropost.swift
+++ b/Turmeric/Classes/Models/Micropost.swift
@@ -34,7 +34,9 @@ class Micropost {
             switch response {
             case .Success(let json):
                 handler(APIResponse.Success(Micropost(json: json["micropost"])))
-            default: break
+            default:
+                let error = response.error(type: Micropost.self)
+                handler(error)
             }
             
         }
@@ -45,7 +47,9 @@ class Micropost {
             switch response {
             case .Success(let json):
                 handler(APIResponse.Success(Micropost(json: json["micropost"])))
-            default: break
+            default:
+                let error = response.error(type: Micropost.self)
+                handler(error)
             }
         }
     }
@@ -63,7 +67,9 @@ class Micropost {
                     microposts = (json["feed"].array?.map { Micropost(json: $0) })
                 }
                 handler(APIResponse.Success(microposts))
-            default: break
+            default:
+                let error = response.error(type: ([Micropost]?.self)!)
+                handler(error)
             }
         }
     }

--- a/Turmeric/Classes/Models/Relationship.swift
+++ b/Turmeric/Classes/Models/Relationship.swift
@@ -14,7 +14,9 @@ class Relationship {
             switch response {
             case .Success:
                 handler(APIResponse.Success(nil))
-            default: break
+            default:
+                let error = response.error(type: (Any?.self)!)
+                handler(error)
             }
         }
     }
@@ -30,7 +32,9 @@ class Relationship {
             switch response {
             case .Success:
                 handler(APIResponse.Success(nil))
-            default: break
+            default:
+                let error = response.error(type: (Any?.self)!)
+                handler(error)
             }
             
         }

--- a/Turmeric/Classes/Models/User.swift
+++ b/Turmeric/Classes/Models/User.swift
@@ -40,7 +40,8 @@ class User {
             case .Success(let json):
                 handler(APIResponse.Success(User(json: json["user"])))
             default:
-                break
+                let error = response.error(type: User.self)
+                handler(error)
             }
         }
     }
@@ -53,7 +54,8 @@ class User {
             case .Success(let json):
                 handler(APIResponse.Success(User(json: json["user"])))
             default:
-                break
+                let error = response.error(type: User.self)
+                handler(error)
             }
 
         }
@@ -64,7 +66,9 @@ class User {
             switch response {
             case .Success(let json):
                 handler(APIResponse.Success(User(json: json["user"])))
-            default: break
+            default:
+                let error = response.error(type: User.self)
+                handler(error)
             }
         }
     }
@@ -76,7 +80,8 @@ class User {
                 APIClient.token = json["token"].string!
                 handler(APIResponse.Success(nil))
             default:
-                break
+                let error = response.error(type: (Any?.self)!)
+                handler(error)
             }
         }
     }
@@ -89,7 +94,9 @@ class User {
                     Micropost(json: $0)
                     })
                 handler(APIResponse.Success(microposts))
-            default: break
+            default:
+                let error = response.error(type: ([Micropost]?.self)!)
+                handler(error)
             }
         }
     }
@@ -103,7 +110,8 @@ class User {
                     })
                 handler(APIResponse.Success(lists))
             default:
-                break
+                let error = response.error(type: ([List]?.self)!)
+                handler(error)
             }
         }
     }
@@ -114,7 +122,9 @@ class User {
             case .Success(let json):
                 let users: [User]? = (json["following"]["users"].array?.map { User(json: $0) })
                 handler(APIResponse.Success(users))
-            default: break
+            default:
+                let error = response.error(type: ([User]?.self)!)
+                handler(error)
             }
         }
     }
@@ -125,7 +135,9 @@ class User {
             case .Success(let json):
                 let users: [User]? = (json["followers"]["users"].array?.map { User(json: $0) })
                 handler(APIResponse.Success(users))
-            default: break
+            default:
+                let error = response.error(type: ([User]?.self)!)
+                handler(error)
             }
         }
     }


### PR DESCRIPTION
https://github.com/pepabo-mobile-app-training/turmeric/pull/69 では、APIサーバからのエラーを定義しましたが、そのエラーをどう扱うかまでは実装していませんでした。

現状APIへのリクエストの流れは
Controller -> Model -> APIClient  -> API Server 
となっており、レスポンスの流れは
API Server -> APIClient -> Model -> Controller
となっています。

API サーバ からエラーを受け取った場合、画面にエラーが発生した旨を表示するや適切な画面に遷移させるなどの処理があります。
このことからエラー処理はControllerの責務であることが考えられます。

本PRではAPI サーバがエラーを発生させた場合は、APIClientでエラーの補足、ModelではエラーをそのままControllerに渡す

という処理を実装します。
### やること
- エラーを適切な型に変換しControllerに渡す
  - Model
  - APIClient
### やらないこと
- Controllerでのエラー処理の実装
