### PR TITLE
はじめからリスト名入力フォームにフォーカスをあてて、すぐに入力可能にする

### DIFF
--- a/Turmeric/Classes/Controllers/ListFormViewController.swift
+++ b/Turmeric/Classes/Controllers/ListFormViewController.swift
@@ -30,7 +30,14 @@ class ListFormViewController:  FormViewController{
             }
         }
     }
-    
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // リスト名入力フォームにフォーカスをあてて、はじめからキーボードを出しておく
+        let listName = self.form.rowBy(tag: "listName") as! TextRow
+        listName.cell.textField.becomeFirstResponder()
+    }
+
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.


### PR DESCRIPTION
リスト名のフィールドをタップするという1アクションがあるので、はじめからフォーカスをあててアクションを減らします

![2016-10-13 12 18 54](https://cloud.githubusercontent.com/assets/1928324/19335569/3a97eb02-913f-11e6-969c-3d53d14e6644.png)
