### PR TITLE
プロフィールフィードが正しく表示されない場合がある現象を修正する

### DIFF
--- a/Turmeric/Classes/Controllers/FeedViewController.swift
+++ b/Turmeric/Classes/Controllers/FeedViewController.swift
@@ -3,7 +3,7 @@ import XLPagerTabStrip
 
 class FeedViewController: UITableViewController, IndicatorInfoProvider {
     var itemInfo = IndicatorInfo(title: "Feed")
-    var endpoint = Endpoint.MyFeed
+    var endpoint: Endpoint?
     var microposts = [Micropost]()
 
     var isHome: Bool = false
@@ -69,10 +69,12 @@ class FeedViewController: UITableViewController, IndicatorInfoProvider {
     }
 
     func reloadFeed() {
+        // endpointが指定されていなければ何もしない
+        guard let endpoint = self.endpoint else { return }
         // AppDelegateからログイン完了の通知を受けたらフィードを取得する
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
         appDelegate.loginDispatch.notify(queue: DispatchQueue.main, execute: {
-            Micropost.getFeed(endpoint: self.endpoint) { response in
+            Micropost.getFeed(endpoint: endpoint) { response in
                 switch response {
                 case .Success(let feed):
                     self.microposts = feed!

--- a/Turmeric/Classes/Controllers/OthersProfileViewController.swift
+++ b/Turmeric/Classes/Controllers/OthersProfileViewController.swift
@@ -29,6 +29,7 @@ class OthersProfileViewController: UIViewController, PerformSegueToProfileDelega
 
         let profileFeed = self.childViewControllers[0] as! FeedViewController
         profileFeed.endpoint = Endpoint.UsersMicroposts(self.user!.id)
+        profileFeed.reloadFeed()
     }
 
     override func didReceiveMemoryWarning() {

--- a/Turmeric/Classes/Helpers/Stub.swift
+++ b/Turmeric/Classes/Helpers/Stub.swift
@@ -32,7 +32,7 @@ func enableHTTPStubs() {
             headers: ["Content-Type": "application/json"]
         )
     }
-    stub(condition: isHost("currry.xyz") && isPath("/api/users/6/microposts") && isMethodGET()){_ in
+    stub(condition: isHost("currry.xyz") && isPath("/api/users/101/microposts") && isMethodGET()){_ in
         return OHHTTPStubsResponse(
             fileAtPath: stubFilePath(name: "UsersMicroposts_otherUser.json"),
             statusCode: 200,
@@ -114,7 +114,7 @@ func enableHTTPStubs() {
             headers: ["Content-Type": "application/json"]
         )
     }
-    
+
     //List
     stub(condition: isHost("currry.xyz") && isPath("/api/lists/1") && isMethodGET()){ _ in
         return OHHTTPStubsResponse(
@@ -130,7 +130,7 @@ func enableHTTPStubs() {
             headers: ["Content-Type": "application/json"]
         )
     }
-    
+
     stub(condition: isHost("currry.xyz") && isPath("/api/lists/1") && isMethodPATCH()) { _ in
         return OHHTTPStubsResponse(
             fileAtPath: stubFilePath(name: "ListsUpdate.json"),
@@ -138,11 +138,11 @@ func enableHTTPStubs() {
             headers: ["Content-Type": "application/json"]
         )
     }
-    
+
     stub(condition: isHost("currry.xyz") && isPath("/api/lists/1/members/101") && isMethodDELETE()) { _ in
         return OHHTTPStubsResponse(jsonObject : [], statusCode: 200, headers: nil)
     }
-    
+
     stub(condition: isHost("currry.xyz") && isPath("/api/lists/1/members") && isMethodPOST()) { _ in
         return OHHTTPStubsResponse(jsonObject : [], statusCode: 201, headers: nil)
     }

--- a/Turmeric/Fixtures/MyFeed.json
+++ b/Turmeric/Fixtures/MyFeed.json
@@ -19,11 +19,11 @@
         {
             "id": 7,
             "content": "吾輩は猫である。名前はまだない。どこで生れたか頓と見当がつかぬ。何でも薄暗いじめじめした所でニャーニャー泣いていた事だけは記憶している。吾輩はここで始めて人間というものを見た。しかもあとで聞くとそれは書生という人間中で一番獰悪な種族であったそうだ。この書生というのは時々140文字",
-            "user_id": 6,
+            "user_id": 101,
             "created_at": "2016-10-02T08:08:33.000Z",
             "picture": null,
             "user": {
-                "id": 6,
+                "id": 101,
                 "name": "Other User",
                 "activated": true,
                 "icon_url": "https://secure.gravatar.com/avatar/de9a58df9617af487e8b28dbb3aa50de?s=80",

--- a/Turmeric/Fixtures/UsersFollowers.json
+++ b/Turmeric/Fixtures/UsersFollowers.json
@@ -3,9 +3,10 @@
         "count": 2,
         "users": [
             {
-                "id"       : 101,
-                "name"     : "ry023",
-                "icon_url" : "http://example.com/image/icon1.png",
+                "id": 101,
+                "name": "Other User",
+                "activated": true,
+                "icon_url": "https://secure.gravatar.com/avatar/de9a58df9617af487e8b28dbb3aa50de?s=80",
                 "following_count": 100,
                 "followers_count": 200,
                 "microposts_count": 1000

--- a/Turmeric/Fixtures/UsersFollowers.json
+++ b/Turmeric/Fixtures/UsersFollowers.json
@@ -12,7 +12,7 @@
                 "microposts_count": 1000
             },
             {
-                "id"       : 102,
+                "id"       : 104,
                 "name"     : "shimoju",
                 "icon_url" : "http://example.com/image/icon2.png",
                 "following_count": 100,

--- a/Turmeric/Fixtures/UsersFollowing.json
+++ b/Turmeric/Fixtures/UsersFollowing.json
@@ -3,9 +3,18 @@
         "count": 1,
         "users": [
             {
-                "id"       : 101,
-                "name"     : "ry023",
-                "icon_url" : "http://example.com/image/icon1.png",
+                "id": 101,
+                "name": "Other User",
+                "activated": true,
+                "icon_url": "https://secure.gravatar.com/avatar/de9a58df9617af487e8b28dbb3aa50de?s=80",
+                "following_count": 100,
+                "followers_count": 200,
+                "microposts_count": 1000
+            },
+            {
+                "id"       : 102,
+                "name"     : "shimoju",
+                "icon_url" : "http://example.com/image/icon2.png",
                 "following_count": 100,
                 "followers_count": 200,
                 "microposts_count": 1000
@@ -18,7 +27,6 @@
                 "followers_count": 200,
                 "microposts_count": 1000
             }
-            
         ]
     }
 }

--- a/Turmeric/Fixtures/UsersFollowing.json
+++ b/Turmeric/Fixtures/UsersFollowing.json
@@ -1,6 +1,6 @@
 {
     "following": {
-        "count": 1,
+        "count": 3,
         "users": [
             {
                 "id": 101,
@@ -13,7 +13,7 @@
             },
             {
                 "id"       : 102,
-                "name"     : "shimoju",
+                "name"     : "ry023",
                 "icon_url" : "http://example.com/image/icon2.png",
                 "following_count": 100,
                 "followers_count": 200,

--- a/Turmeric/Fixtures/UsersMicroposts_otherUser.json
+++ b/Turmeric/Fixtures/UsersMicroposts_otherUser.json
@@ -3,113 +3,113 @@
         {
             "id": 201,
             "content": "わたしは他人です",
-            "user_id": 3,
+            "user_id": 101,
             "created_at": "2016-12-20T02:57:38.000Z",
             "picture": null,
             "user": {
-                "id": 3,
+                "id": 101,
                 "name": "Other User",
                 "activated": true,
-                "icon_url": "https://secure.gravatar.com/avatar/d08d4b6a8f375370ad3b1423dca85da8?s=80",
-                "following_count": 5,
-                "followers_count": 7,
-                "microposts_count": 8
+                "icon_url": "https://secure.gravatar.com/avatar/de9a58df9617af487e8b28dbb3aa50de?s=80",
+                "following_count": 100,
+                "followers_count": 200,
+                "microposts_count": 1000
             }
         },
         {
             "id": 191,
             "content": "投稿6",
-            "user_id": 3,
+            "user_id": 101,
             "created_at": "2016-11-16T02:57:38.000Z",
             "picture": null,
             "user": {
-                "id": 3,
+                "id": 101,
                 "name": "Other User",
                 "activated": true,
-                "icon_url": "https://secure.gravatar.com/avatar/d08d4b6a8f375370ad3b1423dca85da8?s=80",
-                "following_count": 5,
-                "followers_count": 7,
-                "microposts_count": 8
+                "icon_url": "https://secure.gravatar.com/avatar/de9a58df9617af487e8b28dbb3aa50de?s=80",
+                "following_count": 100,
+                "followers_count": 200,
+                "microposts_count": 1000
             }
         },
         {
             "id": 121,
             "content": "投稿5",
-            "user_id": 3,
+            "user_id": 101,
             "created_at": "2016-11-10T02:57:38.000Z",
             "picture": null,
             "user": {
-                "id": 3,
+                "id": 101,
                 "name": "Other User",
                 "activated": true,
-                "icon_url": "https://secure.gravatar.com/avatar/d08d4b6a8f375370ad3b1423dca85da8?s=80",
-                "following_count": 5,
-                "followers_count": 7,
-                "microposts_count": 8
+                "icon_url": "https://secure.gravatar.com/avatar/de9a58df9617af487e8b28dbb3aa50de?s=80",
+                "following_count": 100,
+                "followers_count": 200,
+                "microposts_count": 1000
             }
         },
         {
             "id": 110,
             "content": "投稿4",
-            "user_id": 3,
+            "user_id": 101,
             "created_at": "2016-11-09T02:57:38.000Z",
             "picture": null,
             "user": {
-                "id": 3,
+                "id": 101,
                 "name": "Other User",
                 "activated": true,
-                "icon_url": "https://secure.gravatar.com/avatar/d08d4b6a8f375370ad3b1423dca85da8?s=80",
-                "following_count": 5,
-                "followers_count": 7,
-                "microposts_count": 8
+                "icon_url": "https://secure.gravatar.com/avatar/de9a58df9617af487e8b28dbb3aa50de?s=80",
+                "following_count": 100,
+                "followers_count": 200,
+                "microposts_count": 1000
             }
         },
         {
             "id": 31,
             "content": "投稿3",
-            "user_id": 3,
+            "user_id": 101,
             "created_at": "2016-10-20T02:57:38.000Z",
             "picture": null,
             "user": {
-                "id": 3,
+                "id": 101,
                 "name": "Other User",
                 "activated": true,
-                "icon_url": "https://secure.gravatar.com/avatar/d08d4b6a8f375370ad3b1423dca85da8?s=80",
-                "following_count": 5,
-                "followers_count": 7,
-                "microposts_count": 8
+                "icon_url": "https://secure.gravatar.com/avatar/de9a58df9617af487e8b28dbb3aa50de?s=80",
+                "following_count": 100,
+                "followers_count": 200,
+                "microposts_count": 1000
             }
         },
         {
             "id": 21,
             "content": "投稿2",
-            "user_id": 3,
+            "user_id": 101,
             "created_at": "2016-10-12T02:57:38.000Z",
             "picture": null,
             "user": {
-                "id": 3,
+                "id": 101,
                 "name": "Other User",
                 "activated": true,
-                "icon_url": "https://secure.gravatar.com/avatar/d08d4b6a8f375370ad3b1423dca85da8?s=80",
-                "following_count": 5,
-                "followers_count": 7,
-                "microposts_count": 8
+                "icon_url": "https://secure.gravatar.com/avatar/de9a58df9617af487e8b28dbb3aa50de?s=80",
+                "following_count": 100,
+                "followers_count": 200,
+                "microposts_count": 1000
             }
         },
         {
             "id": 5,
             "content": "OtherOtherOther",
-            "user_id": 3,
+            "user_id": 101,
             "created_at": "2016-10-09T02:57:38.000Z",
             "picture": null,
             "user": {
-                "id": 3,
+                "id": 101,
                 "name": "Other User",
                 "activated": true,
-                "icon_url": "https://secure.gravatar.com/avatar/d08d4b6a8f375370ad3b1423dca85da8?s=80",
-                "following_count": 5,
-                "followers_count": 7,
-                "microposts_count": 8
+                "icon_url": "https://secure.gravatar.com/avatar/de9a58df9617af487e8b28dbb3aa50de?s=80",
+                "following_count": 100,
+                "followers_count": 200,
+                "microposts_count": 1000
             }
         }
     ]

--- a/Turmeric/Fixtures/UsersShow.json
+++ b/Turmeric/Fixtures/UsersShow.json
@@ -1,8 +1,9 @@
 {
     "user": {
-        "id"       : 101,
-        "name"     : "ry023",
-        "icon_url" : "http://example.com/image/icon1.png",
+        "id": 101,
+        "name": "Other User",
+        "activated": true,
+        "icon_url": "https://secure.gravatar.com/avatar/de9a58df9617af487e8b28dbb3aa50de?s=80",
         "following_count": 100,
         "followers_count": 200,
         "microposts_count": 1000

--- a/TurmericUITests/OthersProfileUITest.swift
+++ b/TurmericUITests/OthersProfileUITest.swift
@@ -23,11 +23,10 @@ class OthersProfileUITest: XCTestCase {
     func testOthersProfileLayout() {
         //他人プロフィールページへ
         let app = XCUIApplication()
-        app.launch()
         app.tabBars.buttons["プロフィール"].tap()
         app.buttons["profileFollowingCountButton"].tap()
         
-        app.tables.staticTexts["ry023"].tap()
+        app.tables.staticTexts["Other User"].tap()
         
         let profileFollowingCountButton = app.buttons["profileFollowingCountButton"]
         let profileFollowersCountButton = app.buttons["profileFollowersCountButton"]

--- a/TurmericUITests/ProfileUITests.swift
+++ b/TurmericUITests/ProfileUITests.swift
@@ -12,6 +12,8 @@ class ProfileUITests: XCTestCase {
     
     override func setUp() {
         super.setUp()
+        continueAfterFailure = false
+        XCUIApplication().launch()
     }
     
     override func tearDown() {
@@ -21,7 +23,6 @@ class ProfileUITests: XCTestCase {
     func testProfileLayout() {
         //プロフィールページへ
         let app = XCUIApplication()
-        app.launch()
         app.tabBars.buttons["プロフィール"].tap()
         
         let profileFollowingCountButton = app.buttons["profileFollowingCountButton"]
@@ -44,20 +45,19 @@ class ProfileUITests: XCTestCase {
     func testMyFollowers(){
         // ページに移動
         let app = XCUIApplication()
-        app.launch()
         app.tabBars.buttons["プロフィール"].tap()
         app.buttons["profileFollowersCountButton"].tap()
         
         // ユーザ名とフォロー/アンフォローボタンを確認
-        XCTAssert(app.staticTexts["ry023"].exists)
-        XCTAssert(app.tables.cells.containing(.staticText, identifier:"ry023").buttons["アンフォロー"].exists)
+        XCTAssert(app.staticTexts["Other User"].exists)
+        XCTAssert(app.tables.cells.containing(.staticText, identifier:"Other User").buttons["アンフォロー"].exists)
         
         XCTAssert(app.staticTexts["shimoju"].exists)
         XCTAssert(app.tables.cells.containing(.staticText, identifier:"shimoju").buttons["フォロー"].exists)
         
         //アンフォローしたらフォローボタンに変わる
-        app.tables.cells.containing(.staticText, identifier:"ry023").buttons["アンフォロー"].tap()
-        XCTAssert(app.tables.cells.containing(.staticText, identifier:"ry023").buttons["フォロー"].exists)
+        app.tables.cells.containing(.staticText, identifier:"Other User").buttons["アンフォロー"].tap()
+        XCTAssert(app.tables.cells.containing(.staticText, identifier:"Other User").buttons["フォロー"].exists)
         
         //フォローしたらアンフォローボタンに変わる
         app.tables.cells.containing(.staticText, identifier:"shimoju").buttons["フォロー"].tap()
@@ -67,22 +67,21 @@ class ProfileUITests: XCTestCase {
     func testMyFollowing(){
         // ページに移動
         let app = XCUIApplication()
-        app.launch()
         app.tabBars.buttons["プロフィール"].tap()
         app.buttons["profileFollowingCountButton"].tap()
         
         // ユーザ名とアンフォローボタンを確認
-        XCTAssert(app.staticTexts["ry023"].exists)
-        XCTAssert(app.tables.cells.containing(.staticText, identifier:"ry023").buttons["アンフォロー"].exists)
+        XCTAssert(app.staticTexts["Other User"].exists)
+        XCTAssert(app.tables.cells.containing(.staticText, identifier:"Other User").buttons["アンフォロー"].exists)
         
         XCTAssert(!app.staticTexts["shimoju"].exists)   // フォローしていないユーザは表示されない
         
         //アンフォローしたらフォローボタンに変わる
-        app.tables.cells.containing(.staticText, identifier:"ry023").buttons["アンフォロー"].tap()
-        XCTAssert(app.tables.cells.containing(.staticText, identifier:"ry023").buttons["フォロー"].exists)
+        app.tables.cells.containing(.staticText, identifier:"Other User").buttons["アンフォロー"].tap()
+        XCTAssert(app.tables.cells.containing(.staticText, identifier:"Other User").buttons["フォロー"].exists)
         
         //フォローしたらアンフォローボタンに変わる
-        app.tables.cells.containing(.staticText, identifier:"ry023").buttons["フォロー"].tap()
-        XCTAssert(app.tables.cells.containing(.staticText, identifier:"ry023").buttons["アンフォロー"].exists)
+        app.tables.cells.containing(.staticText, identifier:"Other User").buttons["フォロー"].tap()
+        XCTAssert(app.tables.cells.containing(.staticText, identifier:"Other User").buttons["アンフォロー"].exists)
     }
 }


### PR DESCRIPTION
https://github.com/pepabo-mobile-app-training/turmeric/blob/master/Turmeric/Classes/Controllers/ProfileViewController.swift#L29-L32

FeedViewControllerのendpointプロパティで取得しにいくフィードを変えていますが、
プロフィールのフィード(/api/users/:id/microposts)は自分のidがわかっていないとリクエストできないので、getMyUserして取得できたらendpointプロパティに入れています。

しかしこれは非同期のためユーザーを取得してendpointに値が入る前にビューがロードされてしまう場合があり、簡単な対策として取得できたらテーブルをリロードするようにしました。
なので、順番としてはendpointの初期値であるMyFeedを取得・表示したあと、正しいフィードで上書きされるような挙動になっていました
で、リクエストのタイミングの関係か、リロードされずにMyFeedが表示されたままになってしまう場合があることがわかりました

横着せずにendpointプロパティをOptionalにして、nilならリクエストを送らないように変更しました。

（コードは少ないのに説明が長くなってしまった……）
