### PR TITLE
チラつき対策のため、リストが新旧で変化しているときのみリロードする

### DIFF
--- a/Turmeric/Classes/Controllers/HomeViewController.swift
+++ b/Turmeric/Classes/Controllers/HomeViewController.swift
@@ -12,8 +12,15 @@ class HomeViewController: ButtonBarPagerTabStripViewController, PerformSegueToPr
         User.getMyLists() { response in
             switch response {
             case .Success(let lists):
-                self.lists = lists!
-                self.reloadPagerTabStripView()
+                // リストが新旧で変化しているときのみリロードする
+                // FIXME: 当座の対策としてもあまりにもどうかと思いますが、idだけでは名前が変わったのを検出できないのでこうしています
+                let oldList = self.lists.map { String($0.id) + $0.name }
+                let newList = lists!.map { String($0.id) + $0.name }
+
+                if newList != oldList {
+                    self.lists = lists!
+                    self.reloadPagerTabStripView()
+                }
             default: break
             }
         }


### PR DESCRIPTION
現在はviewWillAppearで毎回reloadPagerTabStripViewしてタブを作り直しているので、ホーム画面に戻るたびにリロードのチラつきが発生します。

本来ならば`reloadPagerTabStripView()`や`viewControllers`を賢くして、既に作られているフィードは使いまわしたり、もしくはデータをきちんと永続化するなどすれば解決すると思います。
当座の対策として、取得したリストがこれまでのと変化しているか確認し、新旧で変化しているときのみリロードする形にしました。

コメントにもあるとおり、当座の対策としてもあまりにもどうかと思いますが、idだけでは名前が変わったのを検出できないのでこうしています……
