### PR TITLE
バリデーションメッセージを日本語にする

### DIFF
--- a/Turmeric/Classes/Controllers/LoginViewController.swift
+++ b/Turmeric/Classes/Controllers/LoginViewController.swift
@@ -31,8 +31,23 @@ class LoginViewController: FormViewController{
         form +++ Section()
         <<< EmailRow("email") { row in
                 row.title = "メールアドレス"
+                let emailClosure: ((String?) -> ValidationError?)  = { value in
+                    let errorMessage = "有効なメールアドレスを入力してください。"
+                    if let value = value, !value.isEmpty{
+                        let predicate = NSPredicate(format: "SELF MATCHES %@", "^[_A-Za-z0-9-+]+(\\.[_A-Za-z0-9-+]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*(\\.[A-Za-z‌​]{2,})$")
+                        guard predicate.evaluate(with: value) else {
+                            return ValidationError(msg: errorMessage)
+                        }
+                        return nil
+                    }
+                
+                    return ValidationError(msg: errorMessage)
+                }
+            
+                let emailRule = RuleClosure(validationError: ValidationError(msg: ""), closure: emailClosure)
                 row.add(rule: RuleRequired())
-                row.add(rule: RuleEmail())
+                row.add(rule: emailRule)
+            
                 row.validationOptions = .validatesOnChangeAfterBlurred
             }.cellUpdate { cell, row in
                 if !row.isValid {

--- a/Turmeric/Classes/Controllers/LoginViewController.swift
+++ b/Turmeric/Classes/Controllers/LoginViewController.swift
@@ -32,22 +32,31 @@ class LoginViewController: FormViewController{
         <<< EmailRow("email") { row in
                 row.title = "メールアドレス"
                 let emailClosure: ((String?) -> ValidationError?)  = { value in
-                    let errorMessage = "有効なメールアドレスを入力してください。"
+                    let error = ValidationError(msg: "有効なメールアドレスを入力してください。")
                     if let value = value, !value.isEmpty{
                         let predicate = NSPredicate(format: "SELF MATCHES %@", "^[_A-Za-z0-9-+]+(\\.[_A-Za-z0-9-+]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*(\\.[A-Za-z‌​]{2,})$")
                         guard predicate.evaluate(with: value) else {
-                            return ValidationError(msg: errorMessage)
+                            return error
                         }
                         return nil
                     }
                 
-                    return ValidationError(msg: errorMessage)
+                    return error
                 }
             
-                let emailRule = RuleClosure(validationError: ValidationError(msg: ""), closure: emailClosure)
-                row.add(rule: RuleRequired())
-                row.add(rule: emailRule)
+                let requiredClosure: ((String?) -> ValidationError?) = {value in
+                    let error = ValidationError(msg: "メールアドレスを入力してください。")
+                    if let str = value {
+                        return str.isEmpty ? error : nil
+                    }
+                    return value != nil ? nil : error
+                }
             
+                let emailRule = RuleClosure(closure: emailClosure)
+                let requiredRule = RuleClosure(closure: requiredClosure)
+ 
+                row.add(rule: requiredRule)
+                row.add(rule: emailRule)
                 row.validationOptions = .validatesOnChangeAfterBlurred
             }.cellUpdate { cell, row in
                 if !row.isValid {
@@ -71,7 +80,18 @@ class LoginViewController: FormViewController{
             
         <<< PasswordRow("password") { row in
             row.title = "パスワード"
-            row.add(rule: RuleRequired())
+            
+            let requiredClosure: ((String?) -> ValidationError?) = {value in
+                let error = ValidationError(msg: "パスワードを入力してください。")
+                if let str = value {
+                    return str.isEmpty ? error : nil
+                }
+                return value != nil ? nil : error
+            }
+            
+            let requiredRule = RuleClosure(closure: requiredClosure)
+            row.add(rule: requiredRule)
+            
             }.cellUpdate { cell, row in
                 if !row.isValid {
                     cell.titleLabel?.textColor = .red


### PR DESCRIPTION
https://github.com/pepabo-mobile-app-training/turmeric/pull/96 でバリデーションを実装しましたが、エラーメッセージが英語でした。
我々は日本人なので日本語に変更しようと思います

また、サーバが返すバリデーションメッセージを変更するにはサーバ側のコードを変更しなければならないので本PRには含めません
### やること
- クライアント側でのバリデーションメッセージの日本語化
### やらないこと
- サーバ側でのバリデーションメッセージの日本語化
